### PR TITLE
fix: include server.ts in tsconfig for mcp-use build

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -33,7 +33,10 @@ let streamManager: RedisStreamManager | undefined;
 if (process.env.REDIS_URL && !process.argv.includes("build")) {
   ({ sessionStore, streamManager } = await connectRedis());
 } else if (!process.env.REDIS_URL) {
-  logger.warn("REDIS_URL not set, using in-memory sessions (not deploy-safe)");
+  logger.warn(
+    {},
+    "REDIS_URL not set, using in-memory sessions (not deploy-safe)",
+  );
 }
 
 const server = new MCPServer({

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,6 +16,6 @@
     "skipLibCheck": true,
     "resolveJsonModule": true
   },
-  "include": ["src/**/*", "resources/**/*", ".mcp-use/**/*.d.ts"],
+  "include": ["server.ts", "src/**/*", "resources/**/*", ".mcp-use/**/*.d.ts"],
   "exclude": ["node_modules", "dist"]
 }


### PR DESCRIPTION
Fixes Railway deploy failure where 'mcp-use start' couldn't find the built server.

When SWC was dropped in commit bef77f1, the build changed from 'swc server.ts src -d dist && mcp-use build' to just 'mcp-use build'. However, mcp-use discovers files using tsconfig.json's include patterns, which didn't list server.ts at the project root. This caused esbuild to skip transpiling server.ts, leaving no dist/server.js for mcp-use start to find.

Also fixes a latent type error in server.ts where logger.warn() was called with only one argument instead of the required two.