### PR TITLE
fix(oauth): set issuer to mcpUrl in proxied AS metadata

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -113,6 +113,10 @@ server.app.get("/.well-known/oauth-authorization-server", async c => {
     return c.json({ error: "Failed to fetch auth server metadata" }, 502);
   }
   const metadata = await response.json();
+  // RFC 8414: issuer must match the URL the metadata was discovered at.
+  // Since we proxy AS metadata under mcpUrl, the issuer must be mcpUrl —
+  // otherwise strict clients (e.g. Smithery) reject the discovery response.
+  metadata.issuer = mcpUrl;
   metadata.authorization_endpoint = `${mcpUrl}/oauth/authorize`;
   return c.json(metadata);
 });

--- a/server.ts
+++ b/server.ts
@@ -116,7 +116,8 @@ server.app.get("/.well-known/oauth-authorization-server", async c => {
   // RFC 8414: issuer must match the URL the metadata was discovered at.
   // Since we proxy AS metadata under mcpUrl, the issuer must be mcpUrl —
   // otherwise strict clients (e.g. Smithery) reject the discovery response.
-  metadata.issuer = mcpUrl;
+  // Trailing slash matters: Smithery normalizes the base URL with one.
+  metadata.issuer = mcpUrl.endsWith("/") ? mcpUrl : `${mcpUrl}/`;
   metadata.authorization_endpoint = `${mcpUrl}/oauth/authorize`;
   return c.json(metadata);
 });


### PR DESCRIPTION
## Summary
- The `/.well-known/oauth-authorization-server` proxy was forwarding PropelAuth's `issuer` (`https://auth.meetsquad.ai`) unchanged, but the metadata is served under `mcpUrl`. RFC 8414 requires `issuer` to match the URL where the metadata was discovered.
- Strict clients (e.g. Smithery) reject discovery with `OAUTH_JSON_ATTRIBUTE_COMPARISON_FAILED`:
  > "issuer" is "https://auth.meetsquad.ai" but expected "https://mcp.meetsquad.ai/"
- ChatGPT/Claude don't enforce this check today, so existing flows are unaffected. Token validation continues against the unchanged JWKS URL, and DCR/token endpoints in the metadata still point to PropelAuth.

## Test plan
- [ ] Hit `https://mcp.meetsquad.ai/.well-known/oauth-authorization-server` and confirm `issuer` is `https://mcp.meetsquad.ai` (matching `MCP_URL`).
- [ ] Re-add the server in Smithery — auth flow completes without the discovery error.
- [ ] Verify ChatGPT and Claude existing OAuth connections still work.