### PR TITLE
chore(deps): merge prod and dev dependabot groups

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,13 +8,9 @@ updates:
     labels:
       - dependencies
     groups:
-      production-minor-patch:
-        dependency-type: production
-        update-types:
-          - minor
-          - patch
-      dev-dependencies:
-        dependency-type: development
+      npm-minor-patch:
+        patterns:
+          - "*"
         update-types:
           - minor
           - patch


### PR DESCRIPTION
## Summary
- Combine `production-minor-patch` and `dev-dependencies` into a single `npm-minor-patch` group so all minor/patch npm bumps land in one weekly PR.

## Why
Two separate groups produced two PRs per week against the same lockfile. They merged cleanly individually, but whichever landed second always needed a Dependabot rebase. One combined PR removes that churn.

Majors still arrive as individual PRs (preserved via `update-types`).

A matching change is going up against `the-basilisk-ai/squidge` (#274).

## Test plan
- [ ] Dependabot picks up the new group on its next scheduled run (weekly)