### PR TITLE
chore(deps): pin shell-quote to 1.8.4 to address Dependabot alert

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "ajv": "^8.18.0",
     "basic-ftp": "^5.2.2",
     "picomatch": "^4.0.4",
+    "shell-quote": "^1.8.4",
     "@nestjs/core": "^11.1.18",
     "tar": "^7.5.12",
     "express-rate-limit": "^8.2.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5193,10 +5193,10 @@ shebang-regex@^3.0.0:
   resolved "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz"
   integrity sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==
 
-shell-quote@1.8.3:
-  version "1.8.3"
-  resolved "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz"
-  integrity sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==
+shell-quote@1.8.3, shell-quote@^1.8.4:
+  version "1.8.4"
+  resolved "https://registry.yarnpkg.com/shell-quote/-/shell-quote-1.8.4.tgz#2edd9a4dcefc96649e2e2cb12f637b1f1d92a190"
+  integrity sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==
 
 side-channel-list@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
## Summary

Resolves Dependabot alert **CVE-2026-9277** in `shell-quote` (vulnerable range `>= 1.1.0, <= 1.8.3`, fixed in `1.8.4`).

`shell-quote` is a **transitive** dependency (not declared directly in any `package.json`), so the fix pins it to a safe version via the repo's existing override/resolution mechanism, forcing `1.8.4` across the dependency tree.

## Changes
- Add `shell-quote` pin to the `resolutions` block in package.json (`shell-quote: ^1.8.4`)
- Regenerate lockfile — `shell-quote` now resolves to `1.8.4` everywhere (no `1.8.3` remaining)

## Verification
- Lockfile contains only `shell-quote@1.8.4`
- `yarn build` (typecheck + widget build) passes