### PR TITLE
fix(config): point API and auth URLs at v1 subdomain

### DIFF
--- a/openapi/squad.json
+++ b/openapi/squad.json
@@ -12,15 +12,15 @@
   },
   "servers": [
     {
-      "url": "https://api.meetsquad.ai",
+      "url": "https://api.v1.meetsquad.ai",
       "description": "Production server"
     },
     {
-      "url": "https://uat.api.meetsquad.ai",
+      "url": "https://uat.api.v1.meetsquad.ai",
       "description": "Staging server"
     },
     {
-      "url": "https://dev.api.meetsquad.ai",
+      "url": "https://dev.api.v1.meetsquad.ai",
       "description": "Development server"
     }
   ],

--- a/src/helpers/config.ts
+++ b/src/helpers/config.ts
@@ -8,9 +8,9 @@ export function getPropelAuthUrl(): string {
     return "https://26904088430.propelauthtest.com";
   }
   if (squadEnv === "staging") {
-    return "https://auth.app.meetsquad.ai";
+    return "https://auth.uat.v1.meetsquad.ai";
   }
-  return "https://auth.meetsquad.ai"; // production
+  return "https://auth.v1.meetsquad.ai"; // production
 }
 
 /**
@@ -20,12 +20,12 @@ export function getSquadApiUrl(): string {
   const squadEnv = process.env.SQUAD_ENV || "production";
 
   if (squadEnv === "dev") {
-    return "https://dev.api.meetsquad.ai";
+    return "https://dev.api.v1.meetsquad.ai";
   }
   if (squadEnv === "staging") {
-    return "https://uat.api.meetsquad.ai";
+    return "https://uat.api.v1.meetsquad.ai";
   }
-  return "https://api.meetsquad.ai";
+  return "https://api.v1.meetsquad.ai";
 }
 
 /**

--- a/src/lib/openapi/squad/runtime.ts
+++ b/src/lib/openapi/squad/runtime.ts
@@ -13,7 +13,7 @@
  */
 
 
-export const BASE_PATH = "https://api.meetsquad.ai".replace(/\/+$/, "");
+export const BASE_PATH = "https://api.v1.meetsquad.ai".replace(/\/+$/, "");
 
 export interface ConfigurationParameters {
     basePath?: string; // override base path


### PR DESCRIPTION
## Summary

The Squad API and PropelAuth hosts moved under a versioned `v1` subdomain. This updates all hardcoded and composed URL strings to target the new hosts.

| Old host | New host |
| --- | --- |
| `api.meetsquad.ai` | `api.v1.meetsquad.ai` |
| `dev.api.meetsquad.ai` | `dev.api.v1.meetsquad.ai` |
| `uat.api.meetsquad.ai` | `uat.api.v1.meetsquad.ai` |
| `auth.meetsquad.ai` | `auth.v1.meetsquad.ai` |
| `auth.app.meetsquad.ai` (staging) | `auth.uat.v1.meetsquad.ai` |

The dev auth host (`26904088430.propelauthtest.com`) is unchanged. App URLs (`app.meetsquad.ai`, `dev.meetsquad.ai`, `uat.meetsquad.ai`) and other subdomains (`mcp.`, `assets.`, `docs.`) are unaffected.

## Changes

- `src/helpers/config.ts` — `getSquadApiUrl()` and `getPropelAuthUrl()` return the new hosts per `SQUAD_ENV`.
- `openapi/squad.json` — server URLs in the OpenAPI spec source.
- `src/lib/openapi/squad/runtime.ts` — generated client `BASE_PATH` default (runtime-overridden by `getSquadApiUrl()`, updated for consistency).