### PR TITLE
fix(config): point API and auth URLs at v1 subdomain on main

### DIFF
--- a/openapi/squad.json
+++ b/openapi/squad.json
@@ -12,15 +12,15 @@
   },
   "servers": [
     {
-      "url": "https://api.meetsquad.ai",
+      "url": "https://api.v1.meetsquad.ai",
       "description": "Production server"
     },
     {
-      "url": "https://uat.api.meetsquad.ai",
+      "url": "https://uat.api.v1.meetsquad.ai",
       "description": "Staging server"
     },
     {
-      "url": "https://dev.api.meetsquad.ai",
+      "url": "https://dev.api.v1.meetsquad.ai",
       "description": "Development server"
     }
   ],

--- a/src/helpers/config.ts
+++ b/src/helpers/config.ts
@@ -8,9 +8,9 @@ export function getPropelAuthUrl(): string {
     return "https://26904088430.propelauthtest.com";
   }
   if (squadEnv === "staging") {
-    return "https://auth.app.meetsquad.ai";
+    return "https://auth.uat.v1.meetsquad.ai";
   }
-  return "https://auth.meetsquad.ai"; // production
+  return "https://auth.v1.meetsquad.ai"; // production
 }
 
 /**
@@ -20,12 +20,12 @@ export function getSquadApiUrl(): string {
   const squadEnv = process.env.SQUAD_ENV || "production";
 
   if (squadEnv === "dev") {
-    return "https://dev.api.meetsquad.ai";
+    return "https://dev.api.v1.meetsquad.ai";
   }
   if (squadEnv === "staging") {
-    return "https://uat.api.meetsquad.ai";
+    return "https://uat.api.v1.meetsquad.ai";
   }
-  return "https://api.meetsquad.ai";
+  return "https://api.v1.meetsquad.ai";
 }
 
 /**

--- a/src/lib/openapi/squad/runtime.ts
+++ b/src/lib/openapi/squad/runtime.ts
@@ -13,7 +13,7 @@
  */
 
 
-export const BASE_PATH = "https://api.meetsquad.ai".replace(/\/+$/, "");
+export const BASE_PATH = "https://api.v1.meetsquad.ai".replace(/\/+$/, "");
 
 export interface ConfigurationParameters {
     basePath?: string; // override base path


### PR DESCRIPTION
Cherry-pick of #112 (c9be340, already merged to the v1 branch) onto main.

Why main too: existing connectors hit mcp.meetsquad.ai, which deploys from main. Main still carries the 3.x server with the pre-swap URLs, so production has been broken since the platform URL change. This revives live 3.x immediately, without waiting for the v1.mcp.meetsquad.ai DNS + trigger flip.

Interaction with #111 (M1 rewrite): #111 deletes/rewrites all three files touched here, so when #111 merges this change disappears with the rest of the 3.x code — resolve any conflict by taking the #111 side. This is purely a stopgap for live customers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)