### PR TITLE
docs: add Smithery badge/backlink to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Squad MCP Server
 
+[![smithery badge](https://smithery.ai/badge/squadai/squad)](https://smithery.ai/servers/squadai/squad)
+
 A remote MCP server that brings [Squad](https://meetsquad.ai) — the AI-powered product discovery and strategy platform — directly into your AI workflows. Connect Squad to Claude, ChatGPT, or any MCP-compatible AI assistant to research, ideate, and plan products without context switching.
 
 ## 🚀 Quick Start


### PR DESCRIPTION
Adds the Smithery README badge under the title. It renders a badge and links back to the Smithery server page (https://smithery.ai/servers/squadai/squad), which satisfies Smithery's "Link to Smithery" verification requirement (a backlink in the README).

Paired with the DNS TXT verification record added to the `meetsquad.ai` apex zone.