### PR TITLE
fix: don't report workspace selection as an error

### DIFF
--- a/src/tools/helpers.ts
+++ b/src/tools/helpers.ts
@@ -84,5 +84,22 @@ export function formatWorkspaceSelectionError(
   return message;
 }
 
+/**
+ * Result returned when a tool can't proceed until the user picks a workspace.
+ *
+ * This is expected control flow, not a failure — the user simply belongs to
+ * more than one workspace — so it is returned as a normal (non-error) tool
+ * result. The agent reads the guidance and calls `select_workspace`. Modelling
+ * it as a tool error (`isError: true`) would surface it to error tracking as a
+ * fault, which it is not.
+ */
+export function toolSelectionRequired(error: WorkspaceSelectionRequired): {
+  content: { type: "text"; text: string }[];
+} {
+  return {
+    content: [{ type: "text", text: formatWorkspaceSelectionError(error) }],
+  };
+}
+
 // Re-export for convenience
 export { WorkspaceSelectionRequired };

--- a/src/tools/registry.test.ts
+++ b/src/tools/registry.test.ts
@@ -20,6 +20,11 @@ vi.mock("../lib/logger.js", () => ({
   logger: { debug: vi.fn(), warn: vi.fn(), info: vi.fn(), error: vi.fn() },
 }));
 
+const mockCaptureToolCall = vi.fn();
+vi.mock("../lib/telemetry.js", () => ({
+  captureToolCall: mockCaptureToolCall,
+}));
+
 const { WorkspaceSelectionRequired } = await import("../helpers/getUser.js");
 const { registerTool } = await import("./registry.js");
 
@@ -60,6 +65,7 @@ beforeEach(() => {
   mockGetUserContext.mockReset();
   mockGetWorkspaceSelection.mockReset();
   mockClearWorkspaceSelection.mockReset();
+  mockCaptureToolCall.mockReset();
 });
 
 describe("registerTool", () => {
@@ -104,7 +110,7 @@ describe("registerTool", () => {
     expect(handler).not.toHaveBeenCalled();
   });
 
-  it("formats WorkspaceSelectionRequired with the available options", async () => {
+  it("returns WorkspaceSelectionRequired as a non-error result recorded as ok", async () => {
     const { server, captured } = fakeServer();
     registerTool(server as never, {
       name: "read_thing",
@@ -131,9 +137,14 @@ describe("registerTool", () => {
     });
 
     const result = await captured[0].handler({}, authCtx());
-    expect(result.isError).toBe(true);
+    // Expected control flow, not a fault: no isError, and recorded as ok so it
+    // never surfaces in error tracking.
+    expect(result.isError).toBeUndefined();
     expect(result.content[0].text).toContain("Acme (org-1)");
     expect(result.content[0].text).toContain("Main (ws-1)");
+    expect(mockCaptureToolCall).toHaveBeenCalledWith(
+      expect.objectContaining({ ok: true }),
+    );
   });
 
   it("clears a stale selection on backend 403 and instructs recovery", async () => {

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -11,10 +11,10 @@ import { captureToolCall } from "../lib/telemetry.js";
 import {
   type AuthInfo,
   formatApiError,
-  formatWorkspaceSelectionError,
   getUserId,
   type OAuthServer,
   toolError,
+  toolSelectionRequired,
   WorkspaceSelectionRequired,
 } from "./helpers.js";
 
@@ -122,15 +122,23 @@ export function registerTool<S extends z.ZodType>(
         telemetry(!result.isError);
         return result;
       } catch (error) {
+        if (error instanceof WorkspaceSelectionRequired) {
+          // Expected control flow: the user belongs to multiple workspaces and
+          // must pick one. Record the call as ok and return guidance the agent
+          // acts on, so it never surfaces as a fault in error tracking.
+          logger.debug(
+            { tool: def.name, ms: Date.now() - started },
+            "workspace selection required",
+          );
+          telemetry(true);
+          return toolSelectionRequired(error);
+        }
+
         logger.debug(
           { err: error, tool: def.name, ms: Date.now() - started },
           "tool call failed",
         );
         telemetry(false, { error });
-
-        if (error instanceof WorkspaceSelectionRequired) {
-          return toolError(formatWorkspaceSelectionError(error));
-        }
 
         if (error instanceof SquadApiError && error.status === 403) {
           const stored = await getWorkspaceSelection(userId);


### PR DESCRIPTION
## Problem

When a user belongs to **multiple workspaces**, the MCP shows up in the PostHog **errors** channel with a red `WorkspaceSelectionRequired` issue:

> Multiple workspaces available. Please use the select_workspace tool to choose one.

Nothing actually failed — the user just needs to pick a workspace. This is expected control flow, but it's being reported as a fault and paging the errors channel.

## Root cause

`getUserContext` throws `WorkspaceSelectionRequired` (`src/helpers/getUser.ts:198`) to prompt selection. The central tool wrapper (`src/tools/registry.ts`) caught it in the generic `catch`, which — **before** the `instanceof` check — called `telemetry(false, { error })` and then returned `toolError(...)` (`isError: true`).

Both of those feed PostHog: `captureToolCall` forwards `isError` and the `error` object to `@posthog/mcp` (`src/lib/telemetry.ts:44`), which raises the exception issue → Slack alert.

## Fix

Handle `WorkspaceSelectionRequired` **first**, as the expected outcome it is:
- record the call as **`ok: true`** (no `error` passed → no exception emitted), and
- return the guidance as a **normal, non-error** tool result via a new `toolSelectionRequired` helper.

The agent still reads the message and calls `select_workspace` — behaviour is unchanged for the model; it just stops being classified as a fault. (Resource reads already returned it as normal markdown content, so no change needed there.)

No new error taxonomy / marker class — the fix is simply "don't model an expected branch as a thrown-and-captured error."

## Testing

- Updated `registry.test.ts`: the selection case now asserts the result is **not** `isError` and that telemetry recorded **`ok: true`**.
- `tsc --noEmit` clean; `biome check` clean; full suite green (**104 tests**); `mcp-use build` / type-check pass.