### PR TITLE
docs: update README and USAGE_EXAMPLES for v4 Squad platform migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Pin these so strategy questions need no tool calls:
        │ HTTPS + Bearer Token
        ▼
 ┌──────────────────────────────────────────────┐
-│  Squad MCP Server (mcp-use)                  │
+│  Squad MCP Server                            │
 │  ┌────────────────────────────────────────┐  │
 │  │  OAuth → introspect + verify token     │  │
 │  │  JWT minting → service credentials     │  │

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ Pin these so strategy questions need no tool calls:
 │  └────────────────────────────────────────┘  │
 └──────────────────────────────────────────────┘
        │
-       │ GraphQL (minted JWT)
+       │ Squad API Calls (minted JWT)
        ▼
 ┌──────────────┐
 │  Squad API   │

--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 [![smithery badge](https://smithery.ai/badge/squadai/squad)](https://smithery.ai/servers/squadai/squad)
 
-A remote MCP server that brings [Squad](https://meetsquad.ai) — the AI-powered product discovery and strategy platform — directly into your AI workflows. Connect Squad to Claude, ChatGPT, or any MCP-compatible AI assistant to research, ideate, and plan products without context switching.
+A remote MCP server that brings [Squad](https://meetsquad.ai) — the AI product feedback intelligence platform — directly into your AI workflows. Connect Squad to Claude, ChatGPT, or any MCP-compatible AI assistant to turn raw user feedback into signals, insights, actions, and decision briefs without context switching.
+
+Squad continuously ingests feedback, clusters it into **signals**, distils it into **insights**, and links it to the **actions** and **goals** that move your product forward. The MCP server exposes that same intelligence — read the evidence behind a decision, capture new feedback, and generate decision briefs from your assistant.
 
 ## 🚀 Quick Start
 
@@ -18,55 +20,68 @@ claude mcp add --transport http squad https://mcp.meetsquad.ai/mcp
 
 On first use, you'll be prompted to authenticate via OAuth in your browser.
 
-**Claude Connectors:**
-
-- Coming soon to the Claude MCP directory
-
-**ChatGPT:**
-
-- Coming soon to the ChatGPT plugin store
-
 **Other MCP Clients:**
 
-Connect using `https://mcp.meetsquad.ai/mcp` - OAuth configuration is automatically discovered via the server's `.well-known/oauth-authorization-server` endpoint.
+Connect using `https://mcp.meetsquad.ai/mcp` — OAuth configuration is automatically discovered via the server's `.well-known/oauth-protected-resource` metadata (which points clients at PropelAuth as the authorization server).
 
 ## 📖 Usage Examples
 
-See **[USAGE_EXAMPLES.md](./USAGE_EXAMPLES.md)** for detailed real-world examples including:
+See **[USAGE_EXAMPLES.md](./USAGE_EXAMPLES.md)** for detailed real-world examples. A few things you can ask:
 
-- **Discover opportunities** - "What opportunities are in my workspace?"
-- **Explore solutions** - "Show me solutions for [opportunity] with pros/cons"
-- **Strategic alignment** - "How do my solutions map to business goals?" (OST view)
-- **Generate ideas** - "Generate solution ideas for [opportunity]"
-- **Search everything** - "Find all content related to compliance"
-- **Create opportunities** - "Create a new opportunity for [customer pain point]"
+- **Triage feedback** — "Capture this support ticket in Squad and tell me if it's a known theme."
+- **Weekly review** — "Run my weekly product review: what changed and what needs deciding?"
+- **Ground the evidence** — "Show me the customer signals behind insight IN-42."
+- **Draft a decision brief** — "Generate a decision brief for action AC-12."
+- **Search everything** — "Find all feedback related to onboarding friction."
+- **Ground a ticket** — "Pull the customer evidence behind AC-7 before I build it."
 
-Each example shows the actual user prompt, which tools get called behind the scenes, and the expected output based on real Squad data.
+Squad entities are referenced by short **display IDs** so the assistant can cite its evidence:
+
+| Prefix | Entity          | Prefix | Entity            |
+| ------ | --------------- | ------ | ----------------- |
+| `SI-`  | Signal          | `GL-`  | Goal              |
+| `CL-`  | Cluster         | `RQ-`  | Research question |
+| `IN-`  | Insight         | `OP-`  | Decision brief    |
+| `AC-`  | Action          | `DC-`  | Document          |
 
 ## ✨ Available Tools
 
-The Squad MCP server provides 30+ tools across 9 categories:
+The server exposes ~35 tools. Write tools require a token minted with the `write:workspace` scope; read tools only need `read:workspace`.
 
-| Category          | Tools                                                                                                                                             | Purpose                                      |
-| ----------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------- |
-| **Opportunities** | `list_opportunities`, `get_opportunity`, `create_opportunity`, `update_opportunity`, `delete_opportunity`, `generate_solutions`, `manage_opportunity_relationships` | Discover and refine product opportunities |
-| **Solutions**     | `list_solutions`, `get_solution`, `create_solution`, `update_solution`, `delete_solution`, `manage_solution_relationships`, `prioritise_solutions` | Generate and iterate on solution ideas       |
-| **Goals**         | `list_goals`, `get_goal`, `create_goal`, `update_goal`, `delete_goal`, `manage_goal_relationships`                                                | Define and track business objectives         |
-| **Knowledge**     | `list_knowledge`, `get_knowledge`, `create_knowledge`, `delete_knowledge`                                                                         | Store research, references, and insights     |
-| **Feedback**      | `list_feedback`, `get_feedback`, `create_feedback`, `delete_feedback`                                                                             | Manage customer and stakeholder feedback     |
-| **Insights**      | `list_insights`, `get_insight`, `create_insight`, `delete_insight`                                                                                | Track customer insights and feature requests |
-| **Workspace**     | `list_workspaces`, `select_workspace`, `get_workspace`, `update_workspace`                                                                        | Configure workspace settings                 |
-| **Search**        | `similarity_search`                                                                                                                               | Semantic search across all entities          |
-| **Views**         | `view_strategy_context`, `view_roadmap`                                                                                                           | Rich visual strategy and roadmap widgets     |
+| Category         | Tools                                                                                                          | Purpose                                          |
+| ---------------- | -------------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
+| **Workspace**    | `list_workspaces`, `select_workspace`, `get_workspace_overview`, `update_workspace`, `list_members`            | Orient in and configure a workspace              |
+| **Search**       | `search`, `get_entity`                                                                                          | Semantic search and fetch any entity by ID       |
+| **Evidence**     | `list_signals`, `find_similar_signals`, `list_clusters`, `get_cluster`, `list_insights`                        | Explore signals, clusters, and insights          |
+| **Actions**      | `list_actions`, `get_action_context`, `update_action`, `update_action_status`                                  | Track and update product work                    |
+| **Strategy**     | `list_goals`, `create_goal`, `update_goal`, `list_research_questions`, `create_research_question`, `update_insight`, `dismiss_signal`, `get_activity` | Manage goals, research questions, and activity   |
+| **Knowledge**    | `list_documents`, `create_document`, `update_document`                                                          | Store research, references, and notes            |
+| **Decision briefs** | `list_one_pagers`, `generate_one_pager`, `update_one_pager_status`                                           | Generate and manage one-page decision briefs     |
+| **Ingest**       | `ingest_signal`                                                                                                 | Capture new feedback as a signal (with dedup)    |
+| **Integrations** | `list_integrations`                                                                                             | See connected feedback sources                   |
+
+### Prompts
+
+Ready-made workflows exposed as MCP prompts:
+
+- **`triage-feedback`** — check for duplicates, ingest a piece of feedback, and report where it landed.
+- **`weekly-product-review`** — what changed, what the evidence says, and what needs deciding.
+- **`draft-decision-brief`** — generate a decision brief from an action or insight and walk it to a readable draft.
+- **`ground-this-ticket`** — for coding agents: pull the customer evidence behind a piece of work before building it.
+
+### Resources
+
+Pin these so strategy questions need no tool calls:
+
+- **`squad://workspace/context`** — the current workspace's mission and product context.
+- **`squad://goals`** — the workspace's strategic goals with importance rankings.
 
 ### Tool Capabilities
 
-All tools include:
-
-- ✅ Safety annotations (`readOnlyHint` / `destructiveHint`)
-- ✅ Structured JSON schemas for inputs/outputs
-- ✅ User-isolated data access via OAuth
-- ✅ Relationship management between entities
+- ✅ Safety annotations (`readOnlyHint` / `destructiveHint`) on every tool
+- ✅ Structured Zod input schemas
+- ✅ User- and workspace-isolated data access via OAuth
+- ✅ Scope-gated writes (`write:workspace`)
 
 ## 🏗️ Architecture
 
@@ -79,44 +94,24 @@ All tools include:
        │ HTTPS + Bearer Token
        ▼
 ┌──────────────────────────────────────────────┐
-│  Squad MCP Server                            │
+│  Squad MCP Server (mcp-use)                  │
 │  ┌────────────────────────────────────────┐  │
-│  │  OAuth Middleware → Validate Token     │  │
-│  │  JWT Minting → Service Credentials    │  │
-│  │  Session Store → Manage State          │  │
-│  │  MCP Handler → Execute Tools           │  │
+│  │  OAuth → introspect + verify token     │  │
+│  │  JWT minting → service credentials     │  │
+│  │  Redis → sessions + stream state       │  │
+│  │  MCP handler → tools / prompts / res.  │  │
+│  │  PostHog → tool-call telemetry         │  │
 │  └────────────────────────────────────────┘  │
 └──────────────────────────────────────────────┘
        │
-       │ Squad API Calls (minted JWT)
+       │ GraphQL (minted JWT)
        ▼
 ┌──────────────┐
 │  Squad API   │
 └──────────────┘
 ```
 
-## 📦 NPM Package
-
-For programmatic access to Squad tools in your Node.js applications:
-
-```bash
-npm install @squadai/tools
-```
-
-```typescript
-import { tools as squadTools } from "@squadai/tools";
-
-// Use with Vercel AI SDK
-const result = await generateText({
-  model: anthropic("claude-3-5-sonnet-20241022"),
-  tools: squadTools({
-    jwt: "YOUR_JWT_TOKEN",
-    orgId: "org-123",
-    workspaceId: "ws-456",
-  }),
-  prompt: "List my current product opportunities",
-});
-```
+The server is built on [`mcp-use`](https://github.com/mcp-use/mcp-use) and talks to the Squad platform API over **GraphQL**. Sessions and stream state are backed by **Redis** so the deployment is horizontally scalable. Backend types are generated from a committed GraphQL schema snapshot (see [GraphQL codegen](#graphql-codegen)).
 
 ## 🛠️ Development
 
@@ -124,11 +119,11 @@ This repository contains the source code for the Squad MCP remote server.
 
 ### Prerequisites
 
-- Node.js 22.22+
+- Node.js 22+
 - Yarn
-- Nix (optional, for reproducible dev environment via `flake.nix`)
-- PropelAuth account (for OAuth2)
-- Squad API credentials
+- Nix (optional, for a reproducible dev environment via `flake.nix`)
+- PropelAuth credentials (OAuth 2.1 client + backend API key)
+- Redis (optional locally; falls back to in-memory sessions)
 
 ### Local Setup
 
@@ -142,7 +137,7 @@ yarn install
 
 # Configure environment
 cp .env.example .env
-# Edit .env with your PropelAuth credentials
+# Edit .env with your PropelAuth credentials (and SQUAD_ENV=dev to target the dev platform)
 
 # Start development server with hot reload
 yarn dev
@@ -150,17 +145,31 @@ yarn dev
 # Server available at http://localhost:3232
 ```
 
+### Environment Variables
+
+| Variable                                                          | Required | Purpose                                                        |
+| ----------------------------------------------------------------- | -------- | -------------------------------------------------------------- |
+| `PROPELAUTH_CLIENT_ID` / `PROPELAUTH_CLIENT_SECRET`               | ✅       | OAuth 2.1 client credentials for token introspection           |
+| `PROPELAUTH_API_KEY`                                              | ✅       | Backend integration key for minting service JWTs               |
+| `SQUAD_ENV`                                                       |          | `dev` or `production` (default `production`) — selects auth/API/app URLs |
+| `PORT` / `MCP_URL` / `BASE_URI`                                   |          | Server port and externally-advertised base URL                 |
+| `REDIS_URL`                                                       |          | Redis connection for deploy-safe sessions (in-memory if unset) |
+| `SQUAD_GRAPHQL_URL`                                               |          | Override the Squad GraphQL endpoint (also used by codegen)     |
+| `POSTHOG_API_KEY` / `POSTHOG_HOST`                                |          | Enable tool-call telemetry                                     |
+| `LOG_LEVEL`                                                       |          | Logger verbosity                                               |
+
 ### Available Commands
 
 ```bash
-yarn build              # Compile TypeScript
-yarn dev                # Start dev server with hot reload
-yarn start              # Start production server
+yarn dev                # Start dev server with hot reload (mcp-use)
+yarn build              # Build the server (mcp-use)
+yarn start              # Start the built server
+yarn deploy             # Deploy via mcp-use
 yarn test               # Run unit tests (vitest)
-yarn format             # Lint with biome
-yarn format:fix         # Auto-fix lint issues
-yarn openapi:squad      # Regenerate API client from OpenAPI spec
-yarn storybook          # Run Storybook for widget development
+yarn format             # Lint/format check (biome)
+yarn format:fix         # Auto-fix lint/format issues
+yarn codegen            # Regenerate GraphQL types from schema.graphql
+yarn codegen:check      # Fail if generated GraphQL types are stale
 ```
 
 ### Testing the Server
@@ -170,57 +179,54 @@ yarn storybook          # Run Storybook for widget development
 curl http://localhost:3232/health
 
 # Check OAuth discovery
-curl http://localhost:3232/.well-known/oauth-authorization-server
+curl http://localhost:3232/.well-known/oauth-protected-resource
 
-# Test with MCP Inspector
-npx @modelcontextprotocol/inspector
-# Then connect to http://localhost:3232/mcp
+# Test with the built-in inspector
+yarn dev   # then open the inspector and connect to http://localhost:3232/mcp
 ```
 
 ### Project Structure
 
 ```
 squad-mcp/
-├── index.ts                    # MCP server entry point with OAuth
-├── server.json                 # MCP registry metadata
+├── server.ts                   # MCP server entry point (OAuth, Redis, tool/prompt/resource registration)
+├── server.json                 # MCP registry metadata (see MCP_REGISTRY.md)
+├── schema.graphql              # Committed snapshot of the Squad platform GraphQL schema
+├── codegen.ts                  # GraphQL Code Generator config
 ├── src/
-│   ├── client.ts               # MCP client export
-│   ├── helpers/
-│   │   ├── config.ts           # Environment configuration
-│   │   ├── getUser.ts          # OAuth context + workspace selection
-│   │   └── mintToken.ts        # JWT minting + per-user cache
-│   ├── lib/
-│   │   ├── logger.ts           # Structured logging
-│   │   └── clients/
-│   │       ├── squad.ts        # Squad API client factory
-│   │       └── middleware/     # Bearer token middleware
-│   └── tools/                  # Tool implementations
-│       ├── opportunity.ts
-│       ├── solution.ts
-│       ├── goal.ts
-│       ├── knowledge.ts
-│       ├── feedback.ts
-│       ├── insight.ts
-│       ├── workspace.ts
-│       ├── search.ts
-│       ├── views.ts
-│       └── helpers.ts
-├── resources/                  # React widget components
-│   ├── view-strategy-context/
-│   └── view-roadmap/
+│   ├── tools/                  # Tool implementations, grouped by surface
+│   │   ├── registry.ts         # Single registration path (annotations, errors, telemetry)
+│   │   ├── workspace.ts        # list/select workspaces, overview, members
+│   │   ├── search.ts           # semantic search
+│   │   ├── get-entity.ts       # fetch any entity by display ID / UUID
+│   │   ├── evidence.ts         # signals, clusters, insights
+│   │   ├── actions-read.ts     # list actions, action context
+│   │   ├── actions-write.ts    # update actions + status
+│   │   ├── strategy-read.ts    # goals, research questions, activity
+│   │   ├── strategy-write.ts   # create/update goals, insights, dismiss signals
+│   │   ├── research-write.ts   # create research questions
+│   │   ├── knowledge.ts        # documents + decision briefs (one-pagers)
+│   │   ├── ingest.ts           # ingest new signals
+│   │   └── integrations.ts     # list connected sources
+│   ├── prompts/                # MCP prompt workflows
+│   ├── resources/              # MCP resources (workspace context, goals)
+│   ├── gql/                    # Generated GraphQL types (yarn codegen)
+│   ├── graphql/                # GraphQL operation documents
+│   ├── helpers/                # OAuth, token minting, workspace selection, KV/Redis
+│   └── lib/                    # Squad API client, logger, telemetry
 ├── railway.toml                # Railway deployment config
 └── .env.example                # Environment template
 ```
 
 ## 🏭 Production Deployment
 
-This is a hosted service maintained by Squad. Users connect via OAuth - no self-hosting required.
+This is a hosted service maintained by Squad. Users connect via OAuth — no self-hosting required.
 
-**Architecture Notes (for contributors):**
+**Architecture notes (for contributors):**
 
-- Single-instance deployment on Railway
-- Follows [MCP specification](https://modelcontextprotocol.io/specification/2025-03-26/basic/transports) for stateful HTTP sessions
-- In-memory transport storage (standard per MCP spec)
+- Deployed on Railway with a `/health` readiness check
+- Redis-backed sessions and stream state for horizontal scalability
+- Follows the [MCP specification](https://modelcontextprotocol.io/specification) for streamable HTTP transport
 
 ## 💬 Support
 
@@ -228,19 +234,20 @@ Need help with the Squad MCP server?
 
 - **Email:** support@meetsquad.ai
 - **Documentation:**
-  - [Squad MCP Guide](https://docs.meetsquad.ai/guides/squad-mcp) - Complete setup and integration guide
-  - [USAGE_EXAMPLES.md](./USAGE_EXAMPLES.md) - Real-world usage examples
-- **Issues:** [GitHub Issues](https://github.com/the-basilisk-ai/squad-mcp/issues) - Bug reports and feature requests
+  - [Squad MCP Guide](https://docs.meetsquad.ai/guides/squad-mcp) — complete setup and integration guide
+  - [USAGE_EXAMPLES.md](./USAGE_EXAMPLES.md) — real-world usage examples
+- **Issues:** [GitHub Issues](https://github.com/the-basilisk-ai/squad-mcp/issues) — bug reports and feature requests
 - **Privacy Policy:** [meetsquad.ai/privacy-policy](https://meetsquad.ai/privacy-policy)
-- **Squad Platform:** [meetsquad.ai](https://meetsquad.ai) - Learn about Opportunity Solution Trees
+- **Squad Platform:** [meetsquad.ai](https://meetsquad.ai)
 
 ## 🤝 Contributing
 
-Contributions welcome! Pre-commit hooks run biome lint and vitest automatically. Please ensure:
+Contributions welcome! Pre-commit hooks run biome and vitest automatically. Please ensure:
 
-- `yarn format` passes (biome lint)
+- `yarn format` passes (biome)
 - `yarn build` compiles without errors
 - `yarn test` passes
+- `yarn codegen:check` passes if you touched GraphQL operations
 - All tools include safety annotations
 
 ## 📄 License
@@ -249,13 +256,12 @@ MIT
 
 ## 🔗 Links
 
-- [Squad MCP Documentation](https://docs.meetsquad.ai/guides/squad-mcp) - Complete setup and integration guide
+- [Squad MCP Documentation](https://docs.meetsquad.ai/guides/squad-mcp) — complete setup and integration guide
 - [Squad Platform](https://meetsquad.ai)
 - [MCP Specification](https://modelcontextprotocol.io)
-- [Claude Desktop](https://claude.ai/download)
 - [Issue Tracker](https://github.com/the-basilisk-ai/squad-mcp/issues)
 
-## GraphQL codegen (v4)
+## GraphQL codegen
 
 Backend access is typed via GraphQL Code Generator. `schema.graphql` is a
 committed snapshot of the Squad platform API schema; `src/gql/` is generated

--- a/USAGE_EXAMPLES.md
+++ b/USAGE_EXAMPLES.md
@@ -1,277 +1,261 @@
 # Squad MCP Server - Usage Examples
 
-These examples demonstrate real-world usage of the Squad MCP server with Claude. Each example shows the user prompt, the tools that get called, and the expected outcome.
+These examples demonstrate real-world usage of the Squad MCP server with Claude. Each shows the user prompt, the tools that get called behind the scenes, and the expected outcome.
+
+Squad turns raw user feedback into an **evidence chain**: feedback lands as **signals** (`SI-`), which cluster into recurring themes (`CL-`), distil into **insights** (`IN-`), and point at the **actions** (`AC-`) and **goals** (`GL-`) that move the product. From there you can generate **decision briefs** (`OP-`) and store **documents** (`DC-`). Every answer cites these display IDs so you can trace it back to real customer evidence.
 
 ---
 
-## Example 1: Discover Product Opportunities
+## Example 1: Orient in a Workspace
 
 ### User Prompt
 ```
-"What opportunities are in my Squad workspace? Show me the top 3."
+"What's going on in my Squad workspace this week?"
 ```
 
 ### What Happens Behind the Scenes
-1. Claude calls `select_workspace` to choose your active workspace (if multiple exist)
-2. Claude calls `list_opportunities` to retrieve all opportunities
-3. Claude analyzes and presents the top opportunities based on status and priority
+1. Claude calls `get_workspace_overview` — one call returns the mission, top goals, recent signal activity by source, evidence-chain health, and open work counts.
 
 ### Actual Output
 ```
-Your Squad workspace has 5 opportunities. Here are the top 3:
+**Acme Platform** — Mission: "Make onboarding effortless for every new team."
 
-1. **Advanced AI Agent Customization Engine** (New)
-   - Build customizable AI agent behaviors and predictive prioritization
-     capabilities for enterprise workflows
-   - Status: New, with solutions already generated
+**Top goals:**
+- GL-1 Reduce time-to-first-value (importance 5)
+- GL-3 Cut onboarding support tickets (importance 4)
 
-2. **Enterprise CRM Integration Ecosystem** (New)
-   - Enable seamless integration with major CRM platforms
+**Signal activity (last 7 days):** 42 signals — zendesk 21, intercom 12, gong 9
 
-3. **Regulatory Compliance Automation Suite** (New)
-   - Automate compliance workflows for regulated industries
+**Chain health:** 6 clusters, 4 insights linked to goals, 2 insights unlinked
 
-All opportunities are currently in "New" status and ready for solution generation.
+**Open work:** 7 open actions · 2 decision briefs pending review
+
+[Open in Squad](https://app.meetsquad.ai/acme/platform)
 ```
 
-**Tools Called:**
-- `select_workspace` (if needed)
-- `list_opportunities`
+**Tools Called:** `get_workspace_overview`
 
-**Value Delivered:** Quick overview of what product opportunities exist, enabling rapid context switching and strategic planning.
+**Value Delivered:** A single orientation call before any deeper work — no need to stitch together several list calls to understand the current state.
+
+> If you belong to more than one workspace, Claude will call `list_workspaces` and `select_workspace` first (or a tool will report that a selection is required).
 
 ---
 
-## Example 2: Explore Solutions for an Opportunity
+## Example 2: Triage a Piece of Feedback
 
 ### User Prompt
 ```
-"Show me the solutions for the AI Agent Customization opportunity,
-including which goals it supports."
+"A customer on Zendesk said: 'The CSV export times out on anything over
+10k rows.' Capture this and tell me if it's a known theme."
 ```
 
 ### What Happens Behind the Scenes
-1. Claude calls `get_opportunity` with the opportunity ID
-2. Requests relationships: solutions, outcomes (goals), and insights
-3. Parses the detailed response including PRDs, pros/cons, and goal alignments
+1. Claude calls `search` with the key phrases to see whether this is already known.
+2. Claude calls `ingest_signal` with the feedback (`source: zendesk`, plus `sourceUrl`/`author` when known). Content is deduplicated semantically server-side.
+3. Clustering and insight extraction run asynchronously.
 
 ### Actual Output
 ```
-The **Advanced AI Agent Customization Engine** opportunity has 3 solutions:
+Captured as **SI-214** (source: zendesk).
 
-**Solution 1: Workflow Designer** (Priority solution)
-- Visual interface for customizing AI agent decision-making processes
-- Pros:
-  • Enables enterprise customization without technical expertise
-  • Adapts to diverse methodologies (SAFe, Scrum, custom frameworks)
-  • Maintains AI automation while providing governance compliance
-- Cons:
-  • Complex interface may extend time-to-market
-  • Risk of over-customization affecting AI performance
-  • Extensive testing required across configurations
+This is a known theme — it merged into an existing signal and sits in cluster
+**CL-8 "Export reliability at scale"** (11 signals). It already backs insight
+**IN-19 "Large exports fail silently"** (combined score 78, 11 signals).
 
-**Solution 2: Methodology Templates**
-- Pre-configured AI agent templates for SAFe, Scrum, Kanban, and industry
-  verticals (healthcare, fintech, manufacturing)
-- Pros:
-  • Accelerates enterprise onboarding with ready-made configurations
-  • Reduces implementation risk through proven templates
-  • Enables rapid vertical market expansion
-- Cons:
-  • May not fully address unique enterprise requirements
-  • Requires ongoing maintenance as methodologies evolve
-  • Risk of commoditization
-
-**Solution 3: Impact Predictor** (Planned for next horizon)
-- AI-powered forecasting system that predicts solution impact before implementation
-- Pros:
-  • Reduces enterprise risk with data-driven forecasts
-  • Differentiates through predictive capabilities competitors lack
-  • Improves strategic decision-making
-- Cons:
-  • Requires significant historical data for accurate predictions
-  • Prediction accuracy may vary across industries
-  • Complex ML infrastructure increases operational costs
-
-**Related Goals (Outcomes):**
-1. Accelerate Market Penetration in Enterprise Segment (Priority: 5/5)
-2. Strengthen Product Differentiation Through AI Innovation (Priority: 5/5)
-
-**Supporting Insights:**
-- Feature request: Customizable AI Agent Behavior and Workflow Rules
-- Feature request: AI-Powered Predictive Opportunity Prioritization
+Clustering/insight updates run in the background — check get_activity or
+list_signals shortly to see it reflected.
 ```
 
-**Tools Called:**
-- `get_opportunity` with relationships `["solutions", "outcomes", "insights"]`
+**Tools Called:** `search`, then `ingest_signal` (batch of 1–50 items supported)
 
-**Value Delivered:** Deep dive into solution options with trade-offs clearly laid out, plus visibility into how the opportunity ladders up to strategic goals (Opportunity Solution Tree structure).
+**Value Delivered:** Feedback is captured once, de-duplicated automatically, and immediately placed in the context of existing evidence — so you learn how widespread a complaint is, not just that it happened.
 
 ---
 
-## Example 3: Understand Strategic Alignment (North Star View)
+## Example 3: Explore a Theme and Its Evidence
 
 ### User Prompt
 ```
-"Show me my top business goals and which opportunities support them."
+"What are people saying about exports? Show me the insight and the
+actual quotes behind it."
 ```
 
 ### What Happens Behind the Scenes
-1. Claude calls `list_goals` to get all workspace outcomes
-2. For high-priority goals, Claude calls `get_goal` with relationships to see connected opportunities
-3. Constructs a hierarchy showing goal → opportunities → solutions
+1. Claude calls `list_insights` (ranked by combined score) — or `list_clusters` to browse recurring themes.
+2. For the top insight, Claude calls `get_entity(IN-19, include: ["evidence"])` to pull the supporting signals with their source links.
 
 ### Actual Output
 ```
-Your workspace has 3 strategic goals:
+**IN-19 — "Large exports fail silently"** (combined score 78 · 11 signals · linked to GL-3)
 
-**Goal 1: Accelerate Market Penetration in Enterprise Segment** ⭐ Priority 5/5
-├─ Opportunity: Advanced AI Agent Customization Engine
-│  ├─ Solution: Workflow Designer (Visual interface for custom agent behaviors)
-│  ├─ Solution: Methodology Templates (SAFe, Scrum, Kanban presets)
-│  └─ Solution: Impact Predictor (AI forecasting for ROI predictions)
-│
-├─ Opportunity: Enterprise Multi-Knowledge Base Platform
-└─ Opportunity: Regulatory Compliance Automation Suite
+The evidence:
+- SI-214 (zendesk): "CSV export times out on anything over 10k rows"
+  → https://acme.zendesk.com/tickets/8821
+- SI-198 (intercom): "Export just spins forever for our biggest board"
+- SI-176 (gong): Enterprise call — "we gave up exporting and use the API now"
 
-**Goal 2: Strengthen Product Differentiation Through AI Innovation** ⭐ Priority 5/5
-├─ Opportunity: Advanced AI Agent Customization Engine (shared with Goal 1)
-│  └─ [Same 3 solutions as above]
-│
-└─ Opportunity: Global Localization and Multi-Language AI
-
-**Goal 3: Expand Geographic Presence in High-Growth Markets** ⭐ Priority 4/5
-├─ Opportunity: Global Localization and Multi-Language AI
-└─ Opportunity: Enterprise CRM Integration Ecosystem
-
-**Key Insight:** The "Advanced AI Agent Customization Engine" opportunity
-supports BOTH of your top-priority goals, making it a strategic lever for
-accelerating enterprise adoption while strengthening differentiation.
+This theme sits in cluster CL-8 "Export reliability at scale" and supports
+goal GL-3 (Cut onboarding support tickets). There's an open action against it:
+AC-31 "Stream large exports instead of buffering".
 ```
 
-**Tools Called:**
-- `list_goals`
-- `get_goal` (for each high-priority goal with relationships `["opportunities", "solutions"]`)
+**Tools Called:** `list_insights`, `get_entity` with `include: ["evidence"]` (also `get_cluster` / `find_similar_signals` when drilling into a specific theme)
 
-**Value Delivered:** Clear visibility into strategic alignment - shows how daily work (solutions) ladders up to opportunities and ultimately to north star business outcomes. This is the core of the Opportunity Solution Tree (OST) methodology.
+**Value Delivered:** Insights are grounded in verbatim customer quotes with source links — the assistant never hand-waves; it cites the signals.
 
 ---
 
-## Example 4: Search for Specific Topics
+## Example 4: Weekly Product Review
 
 ### User Prompt
 ```
-"Find everything in my workspace related to 'compliance' or 'regulatory'."
+"Run my weekly product review — what changed, what the evidence says,
+and what needs deciding?"
 ```
 
 ### What Happens Behind the Scenes
-1. Claude calls `similarity_search` with the query terms
-2. Squad's vector search finds semantically similar content across opportunities, solutions, knowledge documents, and insights
-3. Results are ranked by relevance
+1. `get_workspace_overview` for the current state.
+2. `get_activity` to see what changed — including what Squad's agents did versus humans.
+3. `list_insights` sorted by score for the strongest evidence; `get_entity` with `include: ["evidence"]` on the top few to ground them.
+4. `list_actions` for open work and `list_one_pagers` with status `["draft", "in_review"]` for briefs awaiting a decision.
 
-### Expected Output
+### Actual Output
 ```
-Found 8 items related to compliance/regulatory:
+**Weekly Product Review — Acme Platform**
 
-**Opportunities:**
-- Regulatory Compliance Automation Suite (New)
-  "Automate compliance workflows for regulated industries..."
+*What changed*
+- 42 new signals (zendesk 21, intercom 12, gong 9); export complaints up 3×
+- New insight IN-22 "Onboarding checklist ignored on mobile" auto-distilled
+- AC-31 moved to in_progress
 
-**Solutions:**
-- Methodology Templates - Healthcare compliance features
-  "Includes HIPAA-aware acceptance criteria and test cases..."
+*What the evidence says*
+- IN-19 "Large exports fail silently" (score 78) — SI-214, SI-198, SI-176
+- IN-22 "Checklist ignored on mobile" (score 61) — SI-230, SI-231
 
-- Workflow Designer - Compliance guardrails
-  "Policy blocks for data access scopes, PII redaction, mandatory approvals..."
+*Decisions waiting*
+- OP-4 "Stream large exports" — in_review, recommends shipping streaming
+- Top open action: AC-31 (P1) linked to GL-3
 
-**Knowledge Documents:**
-- SOC 2 Requirements Overview
-- GDPR Data Residency Guidelines
+*Suggested focus:* finalise OP-4 and scope the mobile checklist fix.
 
-**Insights:**
-- Feature request: Automated compliance reporting
-- Feedback: "Need better audit trail visibility"
+[Open in Squad](https://app.meetsquad.ai/acme/platform)
 ```
 
-**Tools Called:**
-- `similarity_search` with filters: `["opportunities", "solutions", "knowledge-base", "insights"]`
+**Tools Called:** `get_workspace_overview`, `get_activity`, `list_insights`, `get_entity`, `list_actions`, `list_one_pagers`
 
-**Value Delivered:** Fast semantic search across all Squad entities, helping teams quickly find relevant context without manually browsing categories.
+> This flow is also available as the **`weekly-product-review`** prompt — invoke it directly instead of typing the whole request.
+
+**Value Delivered:** A one-page, evidence-cited review assembled from live data, distinguishing agent-driven changes from human ones.
 
 ---
 
-## Example 5: Generate New Solutions
+## Example 5: Ground a Ticket Before Building
 
 ### User Prompt
 ```
-"The 'AI Agent Customization' opportunity looks interesting.
-Can you generate some fresh solution ideas for it?"
+"I'm about to pick up AC-31. Pull the customer evidence behind it first."
 ```
 
 ### What Happens Behind the Scenes
-1. Claude calls `generate_solutions` with the opportunity ID
-2. Squad's AI Ideation agent analyzes the opportunity context, workspace knowledge, and related insights
-3. Generates 3-5 new solution approaches with descriptions, pros/cons, and preliminary PRDs
+1. Claude calls `get_action_context(AC-31)` — one call returns the action, the insight that motivates it, the top customer signals with source links, and the goals it serves.
 
-### Expected Output
+### Actual Output
 ```
-✨ Generating solutions for "Advanced AI Agent Customization Engine"...
+**AC-31 — "Stream large exports instead of buffering"** (P1 · in_progress · effort M)
 
-Squad's Ideation agent is analyzing:
-- Opportunity context and supporting insights
-- Workspace knowledge base and industry trends
-- Related outcomes and success criteria
-- Comparable solutions from similar opportunities
+*Why:* IN-19 "Large exports fail silently" (score 78, 11 signals) — buffering
+the full result set exhausts memory on large boards.
 
-This typically takes 30-60 seconds. The solutions will include:
-- Detailed descriptions and rationale
-- Pros and cons for each approach
-- Preliminary PRD with requirements and implementation notes
-- Alignment to your strategic goals
+*Customer evidence:*
+- SI-214 (zendesk): "CSV export times out on anything over 10k rows" → ticket link
+- SI-198 (intercom): "Export just spins forever for our biggest board"
+- SI-176 (gong): "we gave up exporting and use the API now"
 
-✅ Complete! 3 new solutions have been added to the opportunity.
-Use "Show me the solutions for AI Agent Customization" to review them.
+*Serves:* GL-3 Cut onboarding support tickets (importance 4)
+
+Acceptance hints implied by the evidence: exports of 10k+ rows should complete
+without timing out; failures should surface an error rather than spin silently.
+
+When you ship, close the loop: update_action_status AC-31 → completed with a
+note referencing the PR.
 ```
 
-**Tools Called:**
-- `generate_solutions` (triggers Squad's AI Ideation agent)
-- Optionally: `get_opportunity` with `relationships=["solutions"]` to show results
+**Tools Called:** `get_action_context`
 
-**Value Delivered:** AI-powered ideation that considers your full product context, saving hours of brainstorming and ensuring solutions are grounded in evidence from your knowledge base and customer feedback.
+> Also available as the **`ground-this-ticket`** prompt — handy for coding agents that need the "why" before implementing.
+
+**Value Delivered:** Everything needed to execute an action in a single call, so work stays anchored to real customer evidence and the strategic goal it serves.
 
 ---
 
-## Example 6: Create a New Opportunity
+## Example 6: Generate a Decision Brief
 
 ### User Prompt
 ```
-"Create a new opportunity called 'Mobile App Performance Issues' -
-we've been seeing complaints about slow load times on iOS."
+"Draft a decision brief for AC-31 so we can decide whether to prioritise it."
 ```
 
 ### What Happens Behind the Scenes
-1. Claude calls `create_opportunity` with the title and description
-2. Squad creates the opportunity in the active workspace
-3. Returns the new opportunity ID and confirmation
+1. Claude calls `generate_one_pager(actionId: "AC-31")` — generation is asynchronous and returns a new `OP-` ID with status `building`.
+2. Claude polls `get_entity(OP-N)` until the status moves past `building`.
+3. Once finalised in review, `update_one_pager_status` moves it to `in_review` or `finalised`.
 
-### Expected Output
+### Actual Output
 ```
-✅ Created opportunity: **Mobile App Performance Issues**
+Started decision brief **OP-7** (status: building) from AC-31…
+…finished.
 
-ID: abc-123-def-456
-Status: New
-Description: Addressing customer complaints about slow load times on iOS
+**OP-7 — "Stream large exports"**
+*Recommendation:* Ship streaming exports next sprint.
+*Evidence:* 11 signals across zendesk/intercom/gong (SI-214, SI-198, SI-176 …),
+tied to GL-3. Support ticket volume from exports is trending up 3× this month.
+*Gaps:* No data on export sizes above 100k rows — worth a research question.
 
-Next steps:
-- Link this to a strategic goal using `manage_opportunity_relationships`
-- Add supporting insights or feedback items
-- Generate solution ideas with "Generate solutions for this opportunity"
+Moved to in_review so the team can sign off. Open it: OP-7 → decision brief.
 ```
 
-**Tools Called:**
-- `create_opportunity`
+**Tools Called:** `generate_one_pager`, `get_entity` (polling), `update_one_pager_status`
 
-**Value Delivered:** Quickly capture new opportunities as they emerge from customer feedback, team discussions, or market research. All opportunities are automatically connected to your workspace knowledge base for context-aware AI assistance.
+> This is the **`draft-decision-brief`** prompt end to end. You can also generate a brief from an insight (`insightId: "IN-19"`) or retry a failed one (`retryOnePagerId`).
+
+**Value Delivered:** A decision-ready, evidence-cited brief produced by Squad's generation pipeline and walked through its review lifecycle — no manual synthesis.
+
+---
+
+## Example 7: Search Everything
+
+### User Prompt
+```
+"Find everything in my workspace related to onboarding friction."
+```
+
+### What Happens Behind the Scenes
+1. Claude calls `search` with the query. Results span signals, insights, actions, goals, documents, and clusters, and come back as display IDs.
+2. Claude follows the best matches with `get_entity` (or `get_action_context` for actions).
+
+### Actual Output
+```
+Matches for "onboarding friction":
+
+Insights
+- IN-22 Onboarding checklist ignored on mobile
+- IN-9  Setup wizard abandoned at step 3
+
+Clusters
+- CL-2 First-run confusion (14 signals)
+
+Actions
+- AC-18 Simplify the setup wizard
+
+Documents
+- DC-5 Onboarding research summary (Q2)
+
+Ask me to open any of these — e.g. "show the evidence behind IN-22".
+```
+
+**Tools Called:** `search` (optionally restricted with `types: ["insight", "action", …]`), then `get_entity`
+
+**Value Delivered:** Fast keyword search across every entity type, returning citable IDs you can drill into immediately.
 
 ---
 
@@ -279,34 +263,45 @@ Next steps:
 
 | User Goal | Example Prompt | Key Tools Used |
 |-----------|----------------|----------------|
-| **Strategic planning** | "What are my top goals and their progress?" | `list_goals`, `get_goal` |
-| **Opportunity discovery** | "Show me opportunities affecting retention" | `list_opportunities`, `similarity_search` |
-| **Solution exploration** | "What solutions exist for [opportunity]?" | `get_opportunity` with relationships |
-| **Ideation** | "Generate solutions for [opportunity]" | `generate_solutions` |
-| **Research** | "Find everything about [topic]" | `similarity_search` |
-| **Context setting** | "Switch to my [workspace name]" | `select_workspace` |
-| **OST visualization** | "How does [solution] support [goal]?" | `get_goal`, `get_opportunity` with relationships |
+| **Orient** | "What's going on this week?" | `get_workspace_overview` |
+| **Capture feedback** | "Log this ticket in Squad" | `search`, `ingest_signal` |
+| **Explore a theme** | "What are people saying about exports?" | `list_insights`, `list_clusters`, `get_cluster` |
+| **See the evidence** | "Show the quotes behind IN-19" | `get_entity` with `include: ["evidence"]` |
+| **Weekly review** | "Run my weekly product review" | `get_activity`, `list_insights`, `list_actions`, `list_one_pagers` |
+| **Ground a ticket** | "Pull the evidence behind AC-31" | `get_action_context` |
+| **Decide** | "Draft a decision brief for AC-31" | `generate_one_pager`, `update_one_pager_status` |
+| **Search** | "Find everything about onboarding" | `search`, `get_entity` |
+| **Switch context** | "Switch to my other workspace" | `list_workspaces`, `select_workspace` |
+
+### Prompts (ready-made workflows)
+
+Several of the flows above ship as MCP **prompts** you can invoke directly: `triage-feedback`, `weekly-product-review`, `draft-decision-brief`, and `ground-this-ticket`.
+
+### Resources (pinnable context)
+
+Pin `squad://workspace/context` (mission + product context) and `squad://goals` (strategic goals) so strategy questions need no tool calls at all.
 
 ---
 
 ## Tips for Best Results
 
-1. **Be specific with opportunity names** - Claude will search for the best match
-2. **Request relationships** - Ask to "include related goals/solutions/insights" for richer context
-3. **Use natural language** - No need to know tool names, just describe what you want
-4. **Follow the OST flow** - Goals → Opportunities → Solutions → Requirements
-5. **Generate then refine** - Let Squad's AI generate solutions first, then iterate on specific ones
+1. **Orient first** — start a session with `get_workspace_overview` (or pin the workspace-context resource) so later answers have grounding.
+2. **Reference display IDs** — mention `IN-19`, `AC-31`, `CL-8`, etc. and Claude will fetch exactly that entity.
+3. **Ask for the evidence** — "show the quotes / signals behind this" pulls verbatim customer feedback with source links.
+4. **Search before ingesting** — for one-off feedback, a quick `search` or `find_similar_signals` avoids duplicates (ingest also de-dupes server-side).
+5. **Async work polls** — brief generation and clustering run in the background; Claude polls `get_entity` / checks `get_activity` until they land.
+6. **Use natural language** — no need to know tool names; just describe what you want.
 
 ---
 
 ## Authentication Note
 
-All examples require OAuth authentication on first use. Claude will prompt you to log in via your browser, then maintain the session across requests. Your data is isolated per workspace and respects all access controls configured in Squad.
+All examples require OAuth authentication on first use. Claude prompts you to log in via your browser, then maintains the session across requests. Data is isolated per workspace and respects Squad's access controls. Write tools (ingest, create/update, generate) require a token minted with the `write:workspace` scope.
 
 ---
 
 ## More Information
 
-- **Full Tool Reference:** See [README.md](./README.md#-available-tools) for complete tool list
-- **Squad Platform:** Visit [meetsquad.ai](https://meetsquad.ai) to learn about Opportunity Solution Trees
-- **Support:** Create an issue at [github.com/the-basilisk-ai/squad-mcp/issues](https://github.com/the-basilisk-ai/squad-mcp/issues)
+- **Full Tool Reference:** See [README.md](./README.md#-available-tools) for the complete tool list, prompts, and resources.
+- **Squad Platform:** Visit [meetsquad.ai](https://meetsquad.ai).
+- **Support:** Create an issue at [github.com/the-basilisk-ai/squad-mcp/issues](https://github.com/the-basilisk-ai/squad-mcp/issues).


### PR DESCRIPTION
## Why

The docs still described the pre-v4 product — opportunities/solutions/OST discovery, the custom `index.ts` server with in-memory sessions and Storybook widgets, and an `@squadai/tools` SDK. None of that survived the v4 migration (#111, #116, #117, #118, #121). This brings both the README and the usage examples in line with what actually ships today.

## README

- **New domain model** — feedback intelligence: signals → clusters → insights → actions → goals → decision briefs, with a display-ID glossary (`SI-`, `CL-`, `IN-`, `AC-`, `GL-`, `RQ-`, `OP-`, `DC-`).
- **Current tool surface** (~35 tools) grouped by module, with read vs. write (`write:workspace` scope) called out.
- **Prompts & resources** — `triage-feedback`, `weekly-product-review`, `draft-decision-brief`, `ground-this-ticket`, and the `squad://workspace/context` / `squad://goals` resources.
- **Architecture** — `mcp-use` + GraphQL + Redis-backed sessions + PropelAuth OAuth + PostHog telemetry.
- **Dev docs** — `server.ts` entry point, updated commands (`mcp-use` build/dev, `codegen`), a full env-var table, and a corrected project structure.
- Removed the obsolete `@squadai/tools` programmatic-SDK section.

## USAGE_EXAMPLES

Replaced every OST/opportunities/solutions example with the current evidence-chain flows, grounded in the real tool inputs/outputs:

- Orient (`get_workspace_overview`)
- Triage/capture feedback (`search` → `ingest_signal`, with dedup)
- Explore a theme and its signal evidence (`list_insights`, `get_entity` with `include: ["evidence"]`)
- Weekly product review (`get_activity`, `list_insights`, `list_actions`, `list_one_pagers`)
- Ground an action before building (`get_action_context`)
- Generate a decision brief (`generate_one_pager` → poll → `update_one_pager_status`)
- Search everything (`search`)

Also cross-references the prompts and resources, and updates the quick-reference table and tips.

Docs-only; no code changes.