### PR TITLE
fix: extend workspace selection TTL from 24 hours to 30 days

### DIFF
--- a/src/helpers/getUser.ts
+++ b/src/helpers/getUser.ts
@@ -33,7 +33,7 @@ export type WorkspaceDirectory = {
   workspaces: WorkspaceInfo[];
 };
 
-const SELECTION_TTL_SECONDS = 24 * 60 * 60;
+const SELECTION_TTL_SECONDS = 30 * 24 * 60 * 60;
 
 const selectionKey = (userId: string) => `mcp:selection:${userId}`;
 


### PR DESCRIPTION
## Why

The last-selected org/workspace (`mcp:selection:${userId}`) persisted for only 24 hours, so active users were forced to re-select their workspace every day for no real benefit. This bumps the TTL to 30 days.

## Safe by design

A stale selection can't grant stale access. It's re-validated on use: if the user's access to the selected workspace has changed, the Squad API returns 403 and `registry.ts` clears the selection and prompts a re-select. So a longer window can only ever save an active user a re-selection — it can't return a workspace they no longer have access to.

## Change

`src/helpers/getUser.ts` — `SELECTION_TTL_SECONDS`: `24 * 60 * 60` → `30 * 24 * 60 * 60`.

No test pins the TTL value, so nothing else needed updating.