### PR TITLE
fix(tools): constrain insight category & status to platform enums

### DIFF
--- a/src/helpers/enums.ts
+++ b/src/helpers/enums.ts
@@ -1,0 +1,65 @@
+/**
+ * Tool-facing enums mirrored from the Squad platform's GraphQL/pgEnum
+ * definitions. The backend rejects values outside these sets, so constraining
+ * the tool schemas here surfaces the valid options to the agent and fails fast
+ * client-side instead of on a round-trip. Keep in sync with the platform
+ * (packages/db/src/schema/tables.ts and the GraphQL schema).
+ */
+
+/** SignalSource — where a signal came from. */
+export const SIGNAL_SOURCES = [
+  "agent",
+  "amplitude",
+  "api",
+  "app_store",
+  "capterra",
+  "document",
+  "file_upload",
+  "g2",
+  "github",
+  "gong",
+  "google_play",
+  "google_reviews",
+  "intercom",
+  "jira",
+  "linear",
+  "manual",
+  "notion",
+  "posthog",
+  "research",
+  "salesforce",
+  "slack",
+  "trustpilot",
+  "typeform",
+  "webhook",
+  "website",
+  "zendesk",
+] as const;
+
+/** SignalType — the kind of feedback a signal represents. */
+export const SIGNAL_TYPES = [
+  "agent_insight",
+  "bug_report",
+  "churn_risk",
+  "competitive_intel",
+  "feature_request",
+  "pain_point",
+  "praise",
+] as const;
+
+/** insight_category pgEnum. */
+export const INSIGHT_CATEGORIES = [
+  "pain_point",
+  "feature_request",
+  "positive_signal",
+  "trend",
+  "risk",
+] as const;
+
+/** insight_status pgEnum. */
+export const INSIGHT_STATUSES = [
+  "active",
+  "stale",
+  "archived",
+  "resolved",
+] as const;

--- a/src/helpers/enums.ts
+++ b/src/helpers/enums.ts
@@ -1,12 +1,17 @@
 /**
- * Tool-facing enums mirrored from the Squad platform's GraphQL/pgEnum
- * definitions. The backend rejects values outside these sets, so constraining
- * the tool schemas here surfaces the valid options to the agent and fails fast
- * client-side instead of on a round-trip. Keep in sync with the platform
- * (packages/db/src/schema/tables.ts and the GraphQL schema).
+ * Tool-facing enum value sets mirrored from the Squad platform. Constraining
+ * the tool schemas surfaces the valid options to the agent and validates
+ * client-side. Keep in sync with the platform (packages/db/src/schema/tables.ts
+ * and the GraphQL schema).
+ *
+ * INSIGHT_CATEGORIES / INSIGHT_STATUSES map to real pgEnums
+ * (insight_category / insight_status) — the platform hard-rejects values
+ * outside these. SIGNAL_SOURCES / SIGNAL_TYPES mirror the GraphQL SignalSource /
+ * SignalType enums used for filtering; note signal source is stored free-form
+ * (varchar) at ingest, so these are the canonical filter set, not a hard limit.
  */
 
-/** SignalSource — where a signal came from. */
+/** SignalSource — the canonical set of signal sources (used for filtering). */
 export const SIGNAL_SOURCES = [
   "agent",
   "amplitude",

--- a/src/tools/evidence.ts
+++ b/src/tools/evidence.ts
@@ -10,6 +10,12 @@ import {
 import { decodeOffsetCursor, encodeOffsetCursor } from "../helpers/cursor.js";
 import { formatDisplayId } from "../helpers/display-id.js";
 import {
+  INSIGHT_CATEGORIES,
+  INSIGHT_STATUSES,
+  SIGNAL_SOURCES,
+  SIGNAL_TYPES,
+} from "../helpers/enums.js";
+import {
   appLink,
   clampLimit,
   emptyResponse,
@@ -20,45 +26,6 @@ import {
 import { execute } from "../lib/squad-api-client.js";
 import { toolError } from "./helpers.js";
 import { type OAuthServer, registerTool } from "./registry.js";
-
-const SIGNAL_SOURCES = [
-  "agent",
-  "amplitude",
-  "api",
-  "app_store",
-  "capterra",
-  "document",
-  "file_upload",
-  "g2",
-  "github",
-  "gong",
-  "google_play",
-  "google_reviews",
-  "intercom",
-  "jira",
-  "linear",
-  "manual",
-  "notion",
-  "posthog",
-  "research",
-  "salesforce",
-  "slack",
-  "trustpilot",
-  "typeform",
-  "webhook",
-  "website",
-  "zendesk",
-] as const;
-
-const SIGNAL_TYPES = [
-  "agent_insight",
-  "bug_report",
-  "churn_risk",
-  "competitive_intel",
-  "feature_request",
-  "pain_point",
-  "praise",
-] as const;
 
 export function registerEvidenceTools(server: OAuthServer) {
   registerTool(server, {
@@ -300,9 +267,17 @@ export function registerEvidenceTools(server: OAuthServer) {
       'Browse distilled insights ranked by combined score, with category/score/status filters or scoped to a goal. Use get_entity(IN-N, include: ["evidence"]) for the supporting signals.',
     schema: z.object({
       goalId: z.string().optional().describe("GL-N or UUID to scope by goal"),
-      category: z.string().optional(),
+      category: z
+        .enum(INSIGHT_CATEGORIES)
+        .optional()
+        .describe(
+          "Filter by category: pain_point, feature_request, positive_signal, trend, or risk",
+        ),
       minScore: z.number().optional().describe("Minimum combined score"),
-      status: z.string().optional(),
+      status: z
+        .enum(INSIGHT_STATUSES)
+        .optional()
+        .describe("Filter by status: active, stale, archived, or resolved"),
       limit: z.number().int().optional(),
       cursor: z.string().optional(),
     }),

--- a/src/tools/ingest.ts
+++ b/src/tools/ingest.ts
@@ -1,5 +1,4 @@
 import { z } from "zod";
-import { SIGNAL_SOURCES } from "../helpers/enums.js";
 import { entityResponse } from "../helpers/responses.js";
 import { type IngestItem, ingestSignals } from "../lib/ingest-client.js";
 import { type OAuthServer, registerTool } from "./registry.js";
@@ -11,8 +10,10 @@ const SignalInput = z.object({
     .string()
     .min(1)
     .describe("The feedback verbatim or a faithful summary"),
+  // Free-form by design: the ingest API accepts any string (default "api")
+  // and stores it as a varchar, so keep this unconstrained.
   source: z
-    .enum(SIGNAL_SOURCES)
+    .string()
     .optional()
     .describe(
       "Where it came from, e.g. zendesk, intercom, slack, gong, manual (default: api)",

--- a/src/tools/ingest.ts
+++ b/src/tools/ingest.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { SIGNAL_SOURCES } from "../helpers/enums.js";
 import { entityResponse } from "../helpers/responses.js";
 import { type IngestItem, ingestSignals } from "../lib/ingest-client.js";
 import { type OAuthServer, registerTool } from "./registry.js";
@@ -11,7 +12,7 @@ const SignalInput = z.object({
     .min(1)
     .describe("The feedback verbatim or a faithful summary"),
   source: z
-    .string()
+    .enum(SIGNAL_SOURCES)
     .optional()
     .describe(
       "Where it came from, e.g. zendesk, intercom, slack, gong, manual (default: api)",

--- a/src/tools/strategy-write.ts
+++ b/src/tools/strategy-write.ts
@@ -17,6 +17,18 @@ import { execute } from "../lib/squad-api-client.js";
 import { toolError } from "./helpers.js";
 import { type OAuthServer, registerTool } from "./registry.js";
 
+// Mirrors the backend insight_category / insight_status pgEnums
+// (packages/db/src/schema/tables.ts). Keep in sync — the platform rejects
+// values outside these sets with "Invalid insight category/status".
+const INSIGHT_CATEGORIES = [
+  "pain_point",
+  "feature_request",
+  "positive_signal",
+  "trend",
+  "risk",
+] as const;
+const INSIGHT_STATUSES = ["active", "stale", "archived", "resolved"] as const;
+
 async function resolveGoalUuid(
   goalId: string,
   ctx: UserContext,
@@ -135,8 +147,16 @@ export function registerStrategyWriteTools(server: OAuthServer) {
       "Curate an insight: set category or status, and link/unlink the goal it supports. Insight titles and descriptions are pipeline-generated and not editable.",
     schema: z.object({
       insightId: z.string().describe("IN-N display ID or UUID"),
-      category: z.string().optional(),
-      status: z.string().optional(),
+      category: z
+        .enum(INSIGHT_CATEGORIES)
+        .optional()
+        .describe(
+          "Insight category: pain_point, feature_request, positive_signal, trend, or risk",
+        ),
+      status: z
+        .enum(INSIGHT_STATUSES)
+        .optional()
+        .describe("Insight status: active, stale, archived, or resolved"),
       linkGoalId: z
         .string()
         .optional()

--- a/src/tools/strategy-write.ts
+++ b/src/tools/strategy-write.ts
@@ -11,23 +11,12 @@ import {
   UpdateInsightMetaDocument,
 } from "../gql/graphql.js";
 import { formatDisplayId } from "../helpers/display-id.js";
+import { INSIGHT_CATEGORIES, INSIGHT_STATUSES } from "../helpers/enums.js";
 import type { UserContext } from "../helpers/getUser.js";
 import { appLink, entityResponse } from "../helpers/responses.js";
 import { execute } from "../lib/squad-api-client.js";
 import { toolError } from "./helpers.js";
 import { type OAuthServer, registerTool } from "./registry.js";
-
-// Mirrors the backend insight_category / insight_status pgEnums
-// (packages/db/src/schema/tables.ts). Keep in sync — the platform rejects
-// values outside these sets with "Invalid insight category/status".
-const INSIGHT_CATEGORIES = [
-  "pain_point",
-  "feature_request",
-  "positive_signal",
-  "trend",
-  "risk",
-] as const;
-const INSIGHT_STATUSES = ["active", "stale", "archived", "resolved"] as const;
 
 async function resolveGoalUuid(
   goalId: string,


### PR DESCRIPTION
## Problem
Insight `category` and `status` are real backend pgEnums (`insight_category` / `insight_status`) but were exposed as bare `z.string()`. The agent had no way to know the valid values, so wrong guesses failed a full round-trip with an opaque `Invalid insight category`, and an invalid `list_insights` filter hits the enum column and errors at the DB.

## Fix — constrain the enum-backed insight params
| Tool | Param | pgEnum |
|------|-------|--------|
| `update_insight` | `category`, `status` | `insight_category` / `insight_status` |
| `list_insights` | `category`, `status` | `insight_category` / `insight_status` |

Each is now `z.enum(...)` with a `.describe()`, so valid values appear in the tool's JSON schema (what the agent reads) and are validated client-side. Shared value sets are centralized in **`src/helpers/enums.ts`**.

## Audited the whole tool surface
Constrained everything that's genuinely a strict backend enum; left alone what isn't:
- **Already `z.enum`:** actions (status/priority/effort/category), signals (source/type/sentiment), clusters (signalType), one-pagers (status/type), search (types).
- **Deliberately free-form:** `ingest_signal.source` — signal source is *not* a pgEnum (the ingest API takes `z.string().default("api")`, the column is `varchar(64)`, and the app's `SIGNAL_SOURCES` is a plain TS const). A non-listed source throws nowhere, so it stays `z.string()`. `SIGNAL_SOURCES`/`SIGNAL_TYPES` remain the canonical set used only for **filter** params (`list_signals`), not as a hard limit.
- **Skipped:** research-question params — that tool is removed in the paired cleanup PR (#127).
- **No enum params:** `workspace`, `integrations`.

## Verification
`tsc` clean, `biome` clean, full suite **104 tests** pass. (A follow-up could promote insight category/status to real GraphQL enums so codegen keeps the MCP in sync automatically.)