### PR TITLE
ci: pin GitHub Actions to full-length commit SHAs

### DIFF
--- a/.github/workflows/claude-pr-assistant.yaml
+++ b/.github/workflows/claude-pr-assistant.yaml
@@ -25,7 +25,7 @@ jobs:
       id-token: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           fetch-depth: 1
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,9 +9,9 @@ jobs:
   ci:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
-      - uses: actions/setup-node@v7
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: "24"
           cache: yarn


### PR DESCRIPTION
## What

Pin all third-party GitHub Actions to immutable 40-character commit SHAs, keeping the original version tag as a trailing comment so Dependabot can still track and bump them.

## Pinned actions

| action | old ref | new SHA | version comment |
|--------|---------|---------|-----------------|
| `actions/checkout` | `v7` | `9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0` | `# v7` |
| `actions/setup-node` | `v7` | `820762786026740c76f36085b0efc47a31fe5020` | `# v7` |

SHAs resolved live from each upstream repo's tag via the GitHub API.

## Floating branch refs (NOT pinned — need a human decision)

| ref | file | why left alone |
|-----|------|----------------|
| `anthropics/claude-code-action@beta` | `.github/workflows/claude-pr-assistant.yaml` | `beta` is a moving branch, not a released tag. Pinning it to a SHA would freeze it permanently and Dependabot cannot bump it (no version to compare against). Recommend moving to the released `@v1` tag (as `claude-code-action` is already used elsewhere in the org) — then it can be pinned + tracked. |

## Unresolved SHAs

None — every tag resolved.

## Dependabot verification

- `.github/dependabot.yml` present with a `github-actions` ecosystem entry, `directory: /`, `interval: weekly`.
- `/` covers `.github/workflows`; there are no composite actions in other paths, so no additional `directory` entries are required.
- **Empirically confirmed running**: Dependabot has opened github-actions PRs on this repo, e.g. #129 (bump `actions/setup-node` 6→7), #103 (bump `actions/checkout` 6→7), #46, #44 — all merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
