### PR TITLE
ci: use CLAUDE_CODE_OAUTH_TOKEN for claude-pr-assistant workflow

### DIFF
--- a/.github/workflows/claude-pr-assistant.yaml
+++ b/.github/workflows/claude-pr-assistant.yaml
@@ -32,5 +32,5 @@ jobs:
       - name: Run Claude PR Action
         uses: anthropics/claude-code-action@beta
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}          
           timeout_minutes: "60"


### PR DESCRIPTION
Switches the claude-pr-assistant workflow from ANTHROPIC_API_KEY to CLAUDE_CODE_OAUTH_TOKEN, matching squidge and squad-cli. Requires a CLAUDE_CODE_OAUTH_TOKEN secret (org or repo level) to be set before merging.