### PR TITLE
ci(claude): pin action SHA and grant actions:read for CI status

### DIFF
--- a/.github/workflows/claude-pr-assistant.yaml
+++ b/.github/workflows/claude-pr-assistant.yaml
@@ -18,11 +18,13 @@ jobs:
       (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
       (github.event_name == 'issues' && contains(github.event.issue.body, '@claude'))
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     permissions:
       contents: read
       pull-requests: read
       issues: read
       id-token: write
+      actions: read
     steps:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -30,7 +32,8 @@ jobs:
           fetch-depth: 1
 
       - name: Run Claude PR Action
-        uses: anthropics/claude-code-action@beta
+        uses: anthropics/claude-code-action@fa7e2f0a29a126f0b81cdcf360561b36e44cf608 # v1
         with:
-          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}          
-          timeout_minutes: "60"
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          additional_permissions: |
+            actions: read


### PR DESCRIPTION
Brings `.github/workflows/claude-pr-assistant.yaml` up to parity with squidge and adds CI-status capability.

## Changes
1. **Pin the action to the current v1 release SHA.** `anthropics/claude-code-action@beta` → `anthropics/claude-code-action@fa7e2f0a29a126f0b81cdcf360561b36e44cf608 # v1`, matching squidge and squad-cli.
2. **Replace the invalid `timeout_minutes` input with a job-level timeout.** `timeout_minutes: "60"` is not a valid v1 action input and was silently ignored. Removed it and added `timeout-minutes: 60` at the job level (sibling of `runs-on:`), matching how squidge does it.
3. **Grant `actions: read`.** Added to the job `permissions:` block and wired into the action via `additional_permissions: |` `actions: read`. Without both, production logs show `The github_ci MCP server requires 'actions: read' permission. Skipping CI server installation.` and Claude can't check CI status on PRs.

Adds CI-status capability across all three org repos (squidge, squad-cli, squad-mcp).