### PR TITLE
chore(security): reduce dependency cooldown from 7 days to 3

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,7 +1,9 @@
-# Wait 7 days before resolving a newly published version, so a compromised
-# fresh release can't be pulled in before it's caught. Only affects resolving
-# new versions; frozen-lockfile installs are unaffected.
-minimumReleaseAge: 10080
+# Wait 3 days before resolving a newly published version, so a compromised
+# fresh release can't be pulled in before it's caught (most npm supply-chain
+# compromises are detected and yanked within ~48h, so 3 days covers the bulk of
+# that window while minimising delay to security patches). Only affects
+# resolving new versions; frozen-lockfile installs are unaffected.
+minimumReleaseAge: 4320
 
 # Reject transitive dependencies resolved from non-registry (git/tarball/etc.)
 # sources, and block updates that would downgrade these security settings.


### PR DESCRIPTION
Reduces `minimumReleaseAge` from `10080` (7 days) to `4320` (3 days) in `pnpm-workspace.yaml`.

## Why

The cooldown exists to avoid auto-resolving a freshly-published, possibly compromised version before the ecosystem catches it. Two things make the flat 7-day value more costly than protective:

- **It delays security patches most of all** — it's what blocked `fast-uri` in the current advisory sweep.
- **The detection curve doesn't need 7 days.** Most npm supply-chain compromises are detected and yanked within ~48h. 3 days captures the bulk of that window at roughly half the patch-delay cost; the genuinely stealthy cases (xz) evade any realistic timer anyway.
- **Flat cooldown is mis-allocated by popularity** — high-download packages get herd-immunity scrutiny within hours, so a 7-day wait buys near-zero marginal safety there.

`trustPolicy: no-downgrade` + provenance attestation remain the primary supply-chain control; the cooldown is a backstop.

## Scope

Config-only, one line + comment. `blockExoticSubdeps` and `trustPolicy` unchanged. Companion PRs make the same change in `squidge` and `squad-cli`.