### PR TITLE
chore: move pnpm overrides into pnpm-workspace.yaml

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,32 +43,5 @@
     "vite": "^8.1.5",
     "vitest": "^4.1.10"
   },
-  "pnpm": {
-    "overrides": {
-      "@modelcontextprotocol/sdk": "^1.29.0",
-      "body-parser": "^2.3.0",
-      "qs": "^6.14.2",
-      "axios": "^1.18.1",
-      "hono": "^4.12.25",
-      "@hono/node-server": "^2.0.10",
-      "fast-uri": "^3.1.3",
-      "minimatch": "^10.2.3",
-      "ajv": "^8.18.0",
-      "basic-ftp": "^5.3.1",
-      "picomatch": "^4.0.4",
-      "@nestjs/core": "^11.1.18",
-      "tar": "^7.5.20",
-      "express-rate-limit": "^8.2.2",
-      "dompurify": "^3.4.12",
-      "brace-expansion": "^5.0.7",
-      "@opentelemetry/core": "^2.8.0",
-      "router>path-to-regexp": "^8.4.0",
-      "follow-redirects": "^1.16.0",
-      "protobufjs": "^7.6.5",
-      "ip-address": "^10.1.1",
-      "esbuild": "^0.28.1",
-      "shell-quote": "^1.10.0"
-    }
-  },
   "packageManager": "pnpm@10.32.1"
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -10,3 +10,30 @@ minimumReleaseAge: 4320
 # Require pnpm >=10.26 / >=10.21 respectively — older pnpm silently ignores them.
 blockExoticSubdeps: true
 trustPolicy: no-downgrade
+
+# Once this file exists, pnpm ignores the `pnpm` field in package.json, so
+# dependency overrides live here.
+overrides:
+  "@modelcontextprotocol/sdk": "^1.29.0"
+  "body-parser": "^2.3.0"
+  "qs": "^6.14.2"
+  "axios": "^1.18.1"
+  "hono": "^4.12.25"
+  "@hono/node-server": "^2.0.10"
+  "fast-uri": "^3.1.3"
+  "minimatch": "^10.2.3"
+  "ajv": "^8.18.0"
+  "basic-ftp": "^5.3.1"
+  "picomatch": "^4.0.4"
+  "@nestjs/core": "^11.1.18"
+  "tar": "^7.5.20"
+  "express-rate-limit": "^8.2.2"
+  "dompurify": "^3.4.12"
+  "brace-expansion": "^5.0.7"
+  "@opentelemetry/core": "^2.8.0"
+  "router>path-to-regexp": "^8.4.0"
+  "follow-redirects": "^1.16.0"
+  "protobufjs": "^7.6.5"
+  "ip-address": "^10.1.1"
+  "esbuild": "^0.28.1"
+  "shell-quote": "^1.10.0"


### PR DESCRIPTION
Relocates squad-mcp's dependency overrides from `package.json` `pnpm.overrides` into `pnpm-workspace.yaml` `overrides:`, matching `squidge` and `squad-cli`.

## Why

Once a `pnpm-workspace.yaml` exists, pnpm ignores the `pnpm` field in `package.json`. squad-mcp currently keeps its overrides there — they still apply today (nothing in the workspace file overrides them), but it's a latent footgun: the day anyone adds an `overrides:` key to the workspace file, the package.json ones would be silently dropped. squad-cli's workspace file already documents exactly this ("the `pnpm` field in package.json is ignored, so overrides live here"). This makes the workspace file the single source of truth across all three repos.

## Change

- Move all 23 overrides into `pnpm-workspace.yaml` `overrides:`.
- Delete the now-empty `pnpm` field from `package.json`.

## Verification

Resolution is **unchanged** — `pnpm install --lockfile-only` is a no-op and the lockfile's applied `overrides:` block is byte-identical (pnpm records the same effective overrides regardless of source). `pnpm build` (TypeScript build + type check) passes.