### PR TITLE
fix(deps): remediate Dependabot security advisories

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,7 +11,7 @@ overrides:
   axios: ^1.18.1
   hono: ^4.12.25
   '@hono/node-server': ^2.0.10
-  fast-uri: ^3.1.3
+  fast-uri: '>=3.1.4 <4'
   minimatch: ^10.2.3
   ajv: ^8.18.0
   basic-ftp: ^5.3.1
@@ -2629,8 +2629,8 @@ packages:
   fast-string-width@3.0.2:
     resolution: {integrity: sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==}
 
-  fast-uri@3.1.3:
-    resolution: {integrity: sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==}
+  fast-uri@3.1.4:
+    resolution: {integrity: sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==}
 
   fast-wrap-ansi@0.2.2:
     resolution: {integrity: sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q==}
@@ -6239,7 +6239,7 @@ snapshots:
   ajv@8.18.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.3
+      fast-uri: 3.1.4
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -6670,7 +6670,7 @@ snapshots:
     dependencies:
       fast-string-truncated-width: 3.0.3
 
-  fast-uri@3.1.3: {}
+  fast-uri@3.1.4: {}
 
   fast-wrap-ansi@0.2.2:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -20,7 +20,7 @@ overrides:
   "axios": "^1.18.1"
   "hono": "^4.12.25"
   "@hono/node-server": "^2.0.10"
-  "fast-uri": "^3.1.3"
+  "fast-uri": ">=3.1.4 <4"
   "minimatch": "^10.2.3"
   "ajv": "^8.18.0"
   "basic-ftp": "^5.3.1"


### PR DESCRIPTION
Remediates the open Dependabot advisory on `the-basilisk-ai/squad-mcp`.

## Fixed

| Package | Change | Type | Alerts |
|---------|--------|------|--------|
| `fast-uri` | override `^3.1.3` → `>=3.1.4 <4` | transitive | #162 |

The existing `fast-uri: ^3.1.3` override resolved to `3.1.3`, which the advisory flags (`<= 3.1.3`). Bumping and bounding it to the 3.x line resolves to `3.1.4`.

## Deferred

None — `fast-uri@3.1.4` is past the 3-day cooldown.

## Policy

No changes to `minimumReleaseAge`, `trustPolicy`, `blockExoticSubdeps`, or the exclude lists.

## Verification

- `pnpm build` passes (TypeScript build + type check)
- lockfile confirms `fast-uri@3.1.4`

Companion PR covers squidge (`next`, `fast-uri`, `find-my-way`). squad-cli has no open alerts.