### PR TITLE
ci: add Semgrep SAST scan workflow

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -1,0 +1,28 @@
+name: Semgrep
+
+on:
+  workflow_dispatch: {}
+  pull_request: {}
+  push:
+    branches:
+      - main
+    paths:
+      - .github/workflows/semgrep.yml
+  schedule:
+    # random HH:MM to avoid a load spike on GitHub Actions at 00:00
+    - cron: '12 15 * * *'
+
+jobs:
+  semgrep:
+    name: SAST Scan
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    env:
+      SEMGREP_APP_TOKEN: ${{ secrets.SEMGREP_APP_TOKEN }}
+    container:
+      image: semgrep/semgrep
+    if: (github.actor != 'dependabot[bot]')
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - run: semgrep ci


### PR DESCRIPTION
Mirrors the SAST workflow already running on `the-basilisk-ai/squidge`.

`semgrep ci` runs on every pull request, daily at 15:12 UTC, on `main` when the workflow file itself changes, and on manual dispatch. Dependabot actors are skipped.

One deviation from squidge: `actions/checkout` is pinned to `3d3c42e5…` (v7.0.1) to match the SHA already used by this repo's other workflows, rather than squidge's older v7.0.0 pin.

## Setup already done

- `SEMGREP_APP_TOKEN` added as a repo secret
- `squad-mcp` added to the `semgrep-app` GitHub App installation, so findings can be commented on PRs

## Note on fork PRs

This repo is public. Pull requests from forks don't receive repo secrets, so `semgrep ci` will run there without a token — it still scans with Semgrep's default rules, but won't report to the Semgrep AppSec Platform. That's a graceful degradation, not a failure.