### PR TITLE
fix(deps): remediate mature Dependabot security advisories

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,7 +17,7 @@ overrides:
   basic-ftp: ^5.3.1
   picomatch: ^4.0.4
   '@nestjs/core': ^11.1.18
-  tar: ^7.5.20
+  tar: ^7.5.21
   express-rate-limit: ^8.2.2
   dompurify: ^3.4.12
   brace-expansion: ^5.0.7
@@ -3736,8 +3736,8 @@ packages:
     resolution: {integrity: sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==}
     engines: {node: '>=6'}
 
-  tar@7.5.20:
-    resolution: {integrity: sha512-9FcyK4PA6+WbzlTM9WhQm6vB5W7cP7dUiPsv1g7YDwEQnQ1CGpK3MGlKk/ITVWMk05kHZuBhmVhiv8LZoy/PFQ==}
+  tar@7.5.22:
+    resolution: {integrity: sha512-MFO/QzvtAOmJbkhOaCTvbGcFN9L9b+JunIsDwaKljSOdcLMea3NJ1k9Usz/rjdfSXTq4dfzfeS7W4p4YOAAHeA==}
     engines: {node: '>=18'}
 
   thenify-all@1.6.0:
@@ -4913,7 +4913,7 @@ snapshots:
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
       react-router-dom: 7.18.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      tar: 7.5.20
+      tar: 7.5.22
       tsx: 4.23.1
       vite: 8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0)
       vite-plugin-singlefile: 2.3.2(rollup@4.62.2)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
@@ -7780,7 +7780,7 @@ snapshots:
 
   tapable@2.3.3: {}
 
-  tar@7.5.20:
+  tar@7.5.22:
     dependencies:
       '@isaacs/fs-minipass': 4.0.1
       chownr: 3.0.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -26,7 +26,7 @@ overrides:
   "basic-ftp": "^5.3.1"
   "picomatch": "^4.0.4"
   "@nestjs/core": "^11.1.18"
-  "tar": "^7.5.20"
+  "tar": "^7.5.21"
   "express-rate-limit": "^8.2.2"
   "dompurify": "^3.4.12"
   "brace-expansion": "^5.0.7"


### PR DESCRIPTION
Remediates the mature open Dependabot advisories in this repo. Companion PR: [squidge#542](https://github.com/the-basilisk-ai/squidge/pull/542). `squad-cli` has no open alerts.

## Fixed

| Alert | Sev | Package | From | To | Change |
|---|---|---|---|---|---|
| [#163](https://github.com/the-basilisk-ai/squad-mcp/security/dependabot/163) | medium | `tar` | 7.5.20 | 7.5.22 | raised the existing override to `^7.5.21` |

## Deferred

**`react-router` ([#164](https://github.com/the-basilisk-ai/squad-mcp/security/dependabot/164), high, GHSA-qwww-vcr4-c8h2)** cannot be fixed from this repo.

The advisory covers `>=7.12.0 <8.3.0` and has no 7.x patch, but the whole `mcp-use` stack holds us on the 7.x line:

- `mcp-use@1.34.5`, `@mcp-use/cli@3.6.6` and `@mcp-use/inspector` all declare `react-router` as a peer at `^7.12.0`, and 1.34.5 is the latest stable release.
- `react-router-dom` has no 8.x line at all (latest is 7.18.2) and depends on `react-router@7.18.1` exactly.

I tested a `react-router: ">=8.3.0 <9"` override. It adds 8.3.0 to the tree but **leaves 7.18.1 in place** via `react-router-dom`, so the alert would not clear, and it breaks every declared peer range. Not worth shipping, so I reverted it.

Two ways forward, both a human call:

1. Wait for an upstream `mcp-use` release on React Router 8.
2. Dismiss the alert as *vulnerable code is not actually used*. The advisory is an **RSC-mode** CSRF bypass. `react-router` reaches us only through the `mcp-use` inspector's client-side dev UI. We do not run React Router in RSC mode and it is not on the MCP server's request path.

## Policy

No change to `minimumReleaseAge`, `blockExoticSubdeps`, `trustPolicy`, or either exclude list. No new exceptions needed.

## Verification

`pnpm install --frozen-lockfile` and `pnpm build` (TypeScript build plus type check) both pass.