### PR TITLE
feat: send HSTS and nosniff on every response

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@graphql-codegen/cli": "^7.2.0",
     "@graphql-codegen/client-preset": "^6.1.0",
     "@types/node": "^24",
-    "hono": "4.12.27",
+    "hono": "^4.12.25",
     "husky": "^9.1.7",
     "tsx": "^4.23.1",
     "typescript": "^7.0.2",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "@graphql-codegen/cli": "^7.2.0",
     "@graphql-codegen/client-preset": "^6.1.0",
     "@types/node": "^24",
+    "hono": "4.12.27",
     "husky": "^9.1.7",
     "tsx": "^4.23.1",
     "typescript": "^7.0.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -80,7 +80,7 @@ importers:
         specifier: ^24
         version: 24.13.3
       hono:
-        specifier: 4.12.27
+        specifier: ^4.12.25
         version: 4.12.27
       husky:
         specifier: ^9.1.7

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -79,6 +79,9 @@ importers:
       '@types/node':
         specifier: ^24
         version: 24.13.3
+      hono:
+        specifier: 4.12.27
+        version: 4.12.27
       husky:
         specifier: ^9.1.7
         version: 9.1.7

--- a/server.ts
+++ b/server.ts
@@ -11,6 +11,7 @@ import { initKv } from "./src/helpers/kv.js";
 import { introspectToken } from "./src/helpers/oauth.js";
 import { connectRedis } from "./src/helpers/redis.js";
 import { logger } from "./src/lib/logger.js";
+import { securityHeaders } from "./src/lib/security-headers.js";
 import { initTelemetry, shutdownTelemetry } from "./src/lib/telemetry.js";
 import { registerPrompts } from "./src/prompts/index.js";
 import { registerResources } from "./src/resources/index.js";
@@ -86,6 +87,9 @@ const server = new MCPServer({
     },
   }),
 });
+
+// Railway's edge adds neither header, so they are set here for every route.
+server.app.use("*", securityHeaders);
 
 // Populate AsyncLocalStorage so tool callbacks can access the Hono context (including auth).
 // mountMcp() doesn't wrap transport.handleRequest() in runWithContext(), so without this

--- a/src/lib/security-headers.test.ts
+++ b/src/lib/security-headers.test.ts
@@ -1,0 +1,51 @@
+import { Hono } from "hono";
+import { describe, expect, it } from "vitest";
+import { securityHeaders } from "./security-headers.js";
+
+function buildApp() {
+  const app = new Hono();
+  app.use("*", securityHeaders);
+
+  app.get("/json", c => c.json({ ok: true }));
+
+  // The MCP transport returns its own streamed Response rather than using the
+  // Hono context helpers, so this is the case the middleware has to survive.
+  app.get(
+    "/stream",
+    () =>
+      new Response(
+        new ReadableStream({
+          start(controller) {
+            controller.enqueue(new TextEncoder().encode("data: hello\n\n"));
+            controller.close();
+          },
+        }),
+        { headers: { "content-type": "text/event-stream" } },
+      ),
+  );
+
+  return app;
+}
+
+describe("securityHeaders", () => {
+  it.each([
+    ["a JSON response", "/json", 200],
+    ["a streamed response", "/stream", 200],
+    ["a 404", "/nowhere", 404],
+  ])("sets both headers on %s", async (_label, path, status) => {
+    const res = await buildApp().request(path);
+
+    expect(res.status).toBe(status);
+    expect(res.headers.get("strict-transport-security")).toBe(
+      "max-age=31536000",
+    );
+    expect(res.headers.get("x-content-type-options")).toBe("nosniff");
+  });
+
+  it("leaves the streamed content-type and body intact", async () => {
+    const res = await buildApp().request("/stream");
+
+    expect(res.headers.get("content-type")).toBe("text/event-stream");
+    await expect(res.text()).resolves.toBe("data: hello\n\n");
+  });
+});

--- a/src/lib/security-headers.ts
+++ b/src/lib/security-headers.ts
@@ -1,0 +1,24 @@
+import type { MiddlewareHandler } from "hono";
+
+// max-age must match the web app and API tiers. includeSubDomains and preload
+// stay off while a subdomain still fails TLS, because preload cannot be undone
+// for the life of the max-age.
+const SECURITY_HEADERS: Record<string, string> = {
+  "Strict-Transport-Security": "max-age=31536000",
+  "X-Content-Type-Options": "nosniff",
+};
+
+/**
+ * Railway's edge does not add either header, so they have to be set here.
+ *
+ * Applied after `next()` and onto `c.res.headers` directly, which is what Hono's
+ * own secure-headers middleware does. Setting them before `next()` would not
+ * survive a handler that returns its own `Response`, and the MCP transport does
+ * exactly that for streamed replies.
+ */
+export const securityHeaders: MiddlewareHandler = async (c, next) => {
+  await next();
+  for (const [name, value] of Object.entries(SECURITY_HEADERS)) {
+    c.res.headers.set(name, value);
+  }
+};


### PR DESCRIPTION
Closes the MCP half of the Missing Security Headers finding from the July 2026 Cognisys pentest (SQ-1490). The web app and API tiers shipped their headers in the-basilisk-ai/squidge#533, #534 and #535.

## Why this is needed here

The compliance statement for that pentest originally claimed the MCP service already sent these headers "via the shared edge". Both halves of that were wrong, and it was checked rather than assumed:

```
mcp.meetsquad.ai      /      404   HSTS: ABSENT   nosniff: ABSENT   server: railway-hikari
mcp.meetsquad.ai      /mcp   401   HSTS: ABSENT   nosniff: ABSENT
dev.mcp.meetsquad.ai  /      404   HSTS: ABSENT   nosniff: ABSENT
dev.mcp.meetsquad.ai  /mcp   401   HSTS: ABSENT   nosniff: ABSENT
```

Railway's edge does not add HSTS. The `/mcp` 401 comes from this service, so the app is answering and setting neither header. A retest scanner would have caught the claim immediately.

## The change

A Hono middleware registered on `"*"`, so it covers `/mcp`, `/health` and the well-known discovery routes:

```
Strict-Transport-Security: max-age=31536000
X-Content-Type-Options: nosniff
```

`max-age` matches the web app and API tiers. Two origins disagreeing on HSTS is worse than either value alone. `includeSubDomains` and `preload` stay off while a subdomain still fails TLS, because preload cannot be undone for the life of the max-age.

## The one non-obvious bit

The headers are set **after** `next()`, onto `c.res.headers`. That is what Hono's own secure-headers middleware does, and it matters here rather than being a style preference: the MCP transport returns its own streamed `Response`, and headers set before `next()` do not survive it.

I verified that instead of assuming it. Moving the assignment to before `next()` fails the streamed case with `expected null to be 'max-age=31536000'` while the JSON and 404 cases still pass, which is exactly the kind of change that would look fine in review and be broken in production on the route that actually matters.

## Tests

`src/lib/security-headers.test.ts` builds a real Hono app and asserts both headers on a JSON response, a streamed `text/event-stream` response and a 404, plus that the streamed content-type and body are untouched.

`hono` is added as a devDependency so the test can construct that app. It is already present transitively at the same version (4.12.27) but pnpm does not hoist it. The source uses a **type-only** import, which the build erases, so nothing new enters the runtime.

## Checks

Ran the full `ci` gate locally: `pnpm format` (clean, exit 0, no diagnostics on the new files), `pnpm codegen:check`, `pnpm build` including the type check, and `pnpm test` (21 files, 103 tests pass).

## After merge

Worth confirming on the deployed service, since the compliance statement asserts it in the present tense:

```
curl -sSI https://mcp.meetsquad.ai/mcp | grep -iE 'strict-transport|content-type-options'
```