### PR TITLE
ci: limit the CI job's GITHUB_TOKEN to contents: read

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   ci:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 


### PR DESCRIPTION
Closes the one open CodeQL alert on this repository.

```
rule:     actions/missing-workflow-permissions   (medium)
file:     .github/workflows/test.yml:10
message:  Actions job or workflow does not limit the permissions of the GITHUB_TOKEN
```

With no `permissions` block the `ci` job inherits the repository default for `GITHUB_TOKEN`, which is broader than the job needs. It only checks out, installs, formats, builds and tests, so `contents: read` covers it.

Set at job level to match `claude-pr-assistant.yaml`, which already scopes its permissions that way. No change to what the checks do.

Found by CodeQL default setup, enabled on this repository earlier today.