### PR TITLE
ci: scan for secrets with gitleaks in CI and pre-commit

### DIFF
--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -1,0 +1,117 @@
+name: Secret Scan
+
+on:
+  workflow_dispatch:
+    inputs:
+      full_history:
+        description: Rescan every commit on every ref instead of the incremental window
+        type: boolean
+        default: false
+  pull_request: {}
+  push:
+    branches:
+      - main
+    paths:
+      - .github/workflows/secret-scan.yml
+      - .gitleaksignore
+  schedule:
+    # random HH:MM to avoid a load spike on GitHub Actions at 00:00
+    - cron: '17 7 * * *'
+
+permissions:
+  contents: read
+
+jobs:
+  gitleaks:
+    name: Secret Scan
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    if: (github.actor != 'dependabot[bot]')
+    env:
+      # Bump the version and the checksum together. The checksum is the linux_x64
+      # line of gitleaks_<version>_checksums.txt on the matching GitHub release.
+      GITLEAKS_VERSION: 8.30.1
+      GITLEAKS_SHA256: 551f6fc83ea457d62a0d98237cbad105af8d557003051f41f3e7ca7b3f2470eb
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+
+      - name: Install gitleaks
+        run: |
+          set -euo pipefail
+          curl -fsSL -o gitleaks.tar.gz \
+            "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz"
+          echo "${GITLEAKS_SHA256}  gitleaks.tar.gz" | sha256sum -c -
+          tar -xzf gitleaks.tar.gz gitleaks
+          sudo install -m 0755 gitleaks /usr/local/bin/gitleaks
+          rm -f gitleaks gitleaks.tar.gz
+
+      - name: Scan
+        id: scan
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          FULL_HISTORY: ${{ inputs.full_history }}
+        run: |
+          set -euo pipefail
+          if [ "$GITHUB_EVENT_NAME" = pull_request ]; then
+            log_opts="--no-merges $BASE_SHA..$HEAD_SHA"
+          elif [ "$FULL_HISTORY" = true ]; then
+            log_opts="--all"
+          else
+            # History up to the recorded baseline has already been scanned in full
+            # and cannot be rewritten, so the daily run is a safety net over the
+            # last week of commits on the default branch: seven runs cover every
+            # commit that landed. Branches are covered by the pull request gate
+            # before they merge. Scanning --all here instead would re-report the
+            # same line once per rebased copy of a commit, which no fingerprint
+            # allowlist can keep up with.
+            log_opts="--no-merges --since=7.days"
+          fi
+          echo "scope: git log $log_opts"
+
+          # --redact=100 keeps secret values out of both the log and the report.
+          # --ignore-gitleaks-allow forces every suppression into .gitleaksignore,
+          # where it is reviewable, instead of an inline comment.
+          gitleaks git . \
+            --no-banner \
+            --redact=100 \
+            --ignore-gitleaks-allow \
+            --exit-code 0 \
+            --log-opts="$log_opts" \
+            --report-format json \
+            --report-path gitleaks-report.json
+
+          count=$(jq length gitleaks-report.json)
+          echo "count=$count" >> "$GITHUB_OUTPUT"
+          {
+            echo "## Secret scan"
+            echo
+            echo "Scope: \`git log $log_opts\`"
+            echo
+            echo "Findings: **$count**"
+            if [ "$count" -gt 0 ]; then
+              echo
+              echo "| Rule | Location | Commit | Author | Fingerprint |"
+              echo "| --- | --- | --- | --- | --- |"
+              jq -r '.[] | "| \(.RuleID) | \(.File):\(.StartLine) | \(.Commit[0:12]) | \(.Author) | `\(.Fingerprint)` |"' \
+                gitleaks-report.json
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload report
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: gitleaks-report
+          path: gitleaks-report.json
+          retention-days: 90
+
+      - name: Fail on findings
+        if: steps.scan.outputs.count != '0'
+        run: |
+          echo "::error::gitleaks found ${{ steps.scan.outputs.count }} potential secret(s)." \
+            "See the job summary for rule, location and fingerprint, and" \
+            "docs/security/secret-scanning.md for what to do next."
+          exit 1

--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -1,0 +1,24 @@
+# gitleaks allowlist. One fingerprint per line, in the form
+# <commit>:<file>:<rule-id>:<line> as printed by the Secret Scan job summary.
+#
+# Two kinds of entry are valid and nothing else:
+#   1. A confirmed false positive: the value is not a credential, or cannot
+#      authenticate to anything.
+#   2. A credential confirmed dead, where a named person decided on a named date
+#      to accept it in history rather than rewrite.
+#
+# Either way the entry carries a comment above it giving the name, the date and the
+# reasoning. An entry without one is not valid and should be rejected in review.
+#
+# A fingerprint pins one rule to one line of one commit, so an entry cannot hide
+# a different finding. Do not add path or regex allowlists to suppress noise in
+# bulk. A live credential is rotated, never suppressed.
+# See docs/security/secret-scanning.md.
+
+# steven 2026-08-02, category 2: PropelAuth access token committed 2025-04-01 in
+# src/opportunity.ts, a file no longer present at HEAD. Issued by a PropelAuth test
+# tenant with a 30-minute expiry, so it is dead and there is nothing to rotate.
+# Accepted in history rather than rewritten, which would break every existing clone.
+# The JWT body still carries a name, an email address and organisation metadata, and
+# this repository is public.
+846cb8870cb36763f4e5e9a9e7adc308e29905f4:src/opportunity.ts:jwt:39

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,2 +1,8 @@
 node_modules/.bin/biome check --staged --no-errors-on-unmatched
 node_modules/.bin/vitest run
+
+if command -v gitleaks >/dev/null 2>&1; then
+  gitleaks git --staged --no-banner --redact=100 --ignore-gitleaks-allow
+else
+  echo "gitleaks not installed, skipping the local secret scan. Run 'nix develop' to get it. CI enforces the same scan."
+fi

--- a/docs/security/secret-scanning.md
+++ b/docs/security/secret-scanning.md
@@ -1,0 +1,94 @@
+# Secret scanning
+
+gitleaks gates every pull request and re-checks a rolling week of commits daily. A
+husky pre-commit hook scans staged changes. Same setup in `squidge` and `squad-cli`.
+The comparison against TruffleHog is in `squidge` at
+`docs/security/secret-scanning.md`.
+
+## How it runs
+
+`.github/workflows/secret-scan.yml`, on pull requests, daily, and on
+`workflow_dispatch`.
+
+Full history was scanned once, recorded below. `main` is protected against
+force-pushes, so routine runs only cover new commits: a pull request run scans
+`base..head`, the daily run scans `--since=7.days` on the default branch. No state
+is committed to the repository for either window.
+
+The daily window deliberately excludes `--all`. Branch commits are already covered by
+the pull request gate, and a rebase gives the same line a new commit SHA, so scanning
+every ref re-reports one value once per copy. Fingerprints are commit-scoped and
+cannot keep up with that.
+
+`workflow_dispatch` with `full_history` rescans everything. Do that after a gitleaks
+upgrade, since new rules invalidate the old baseline.
+
+Every run writes rule, location, commit, author and fingerprint to the job summary
+and uploads a redacted JSON report, retained 90 days. `--redact=100` keeps values
+out of both.
+
+The husky `pre-commit` hook runs `gitleaks git --staged`. It does not replace the CI
+job, which is what blocks a merge, and it skips with a warning if gitleaks is not on
+`PATH`. `nix develop` provides it.
+
+## Baseline scan
+
+`gitleaks git --log-opts="--all"` with gitleaks 8.30.1, every ref up to `7f7fb4e0`,
+2026-08-02. One finding, accepted and allowlisted:
+
+A PropelAuth access token in `src/opportunity.ts`, commit `846cb887`, 2025-04-01, in
+a file no longer present at `HEAD`. It was issued by a PropelAuth test tenant with a
+30-minute expiry, so it expired in April 2025 and there is nothing to rotate. Steven
+accepted it in history on 2026-08-02 rather than rewrite, since a rewrite breaks
+every existing clone and buys nothing against a dead credential. The JWT body still
+carries a name, an email address and organisation metadata, and this repository is
+public, which the decision accepts.
+
+The fingerprint is in `.gitleaksignore` with that reasoning. A `full_history`
+dispatch is clean as a result, so a future finding stands out rather than arriving
+alongside a known one.
+
+## When the scan fires
+
+A failed pull request check is visible to the author and reviewers. A failed
+scheduled run notifies whoever last changed the workflow file; there is no Slack
+alert. Read the job summary rather than the log, and treat every finding as a
+suspected compromise until shown otherwise.
+
+1. Tell the CTO. Rotation is their decision and happens first. Rotate at the
+   provider, then confirm the old value is dead.
+2. Check the provider's audit log for the exposure window, which starts at the
+   commit date in the summary.
+3. Once the credential is dead, decide what to do about the history. Removal means a
+   rewrite that breaks every existing clone.
+4. Record how it was found, when it was rotated, and the exposure.
+
+Do not resolve a real finding with an allowlist entry.
+
+## Adding an allowlist entry
+
+Two cases qualify. A confirmed false positive: the value is not a credential, or
+cannot authenticate to anything. Or a credential confirmed dead, where accepting it
+in history beats a rewrite that would break every clone. Nothing else.
+
+Copy the fingerprint from the job summary into `.gitleaksignore` with a comment
+giving your name, the date and the reasoning. Push it in the pull request the finding
+blocked, so someone other than you reviews the justification.
+
+```
+# steven 2026-08-02: sample response body in a test fixture, the token field is a
+# hand-written placeholder and authenticates to nothing.
+1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d7e8f9a0b:src/__fixtures__/response.json:generic-api-key:12
+```
+
+A fingerprint suppresses one rule on one line of one commit, so an entry cannot mask
+a different finding. Reject entries with no justification, and reject path or regex
+allowlists. `--ignore-gitleaks-allow` disables the inline `gitleaks:allow` comment,
+so every suppression lands in this one file.
+
+## Upgrading gitleaks
+
+Bump `GITLEAKS_VERSION` and `GITLEAKS_SHA256` together. The checksum is the
+`linux_x64` line of `gitleaks_<version>_checksums.txt` on the release. Dependabot
+does not track this pin. After a bump, dispatch with `full_history` and update the
+baseline above.

--- a/flake.nix
+++ b/flake.nix
@@ -20,6 +20,7 @@
             nodePackages.typescript-language-server
             railway
             jdk
+            gitleaks
           ];
         };
       }


### PR DESCRIPTION
## What this does

Adds secret scanning as a detective control: a `Secret Scan` GitHub Actions job
that gates every pull request, re-checks a rolling week of commits daily, and can
rescan the whole history on demand. Alongside it, a husky `pre-commit` hook scans
staged changes so most leaks never leave a laptop. The CI job is the control; the
hook is convenience and skips with a warning when gitleaks is not installed.

## Tool choice

**gitleaks**, not TruffleHog. TruffleHog's headline feature is live-credential
verification, which means posting candidate secrets from our source to third-party
APIs, and its JSON output always carries the plaintext with no redaction flag, so
it cannot meet the "never print a value into the log" requirement without us
writing filtering of our own. gitleaks makes no network calls with findings, is
MIT rather than AGPL, and its `.gitleaksignore` fingerprints pin a suppression to
one rule on one line of one commit so an entry cannot hide anything else.

The full comparison, run over the real history of all three repositories, is in
`squidge` at `docs/security/secret-scanning.md`.

## What the full-history scan found

`gitleaks git --log-opts="--all"` with gitleaks 8.30.1 over every ref up to
`7f7fb4e0`, 2882 commits and 4.8 GB: **one finding**, since accepted and allowlisted.

A PropelAuth access token, committed to `src/opportunity.ts` in commit `846cb887` on
2025-04-01, in a file that no longer exists at `HEAD`. The commit is reachable from
`main`, so it is in the history of every clone, and this repository is public.

The token carried a 30-minute expiry and was issued by a PropelAuth test tenant
(`269040884301.propelauthtest.com`), so it expired in April 2025 and there is nothing
to rotate. Steven took the call on 2026-08-02 to accept it in history rather than
rewrite: a rewrite breaks every existing clone and improves nothing against a dead
credential. The JWT body does still contain a name, an email address and organisation
metadata including a Stripe customer ID, and that is public; the decision accepts it.

The fingerprint is now in `.gitleaksignore` with that reasoning written out, so a
`full_history` dispatch comes back clean and the next finding stands out on its own
rather than arriving next to a known one.

## What is in the allowlist

One fingerprint: the expired token above, with a comment giving who accepted it, when,
and why. The convention in that file now names two valid categories and nothing else,
a confirmed false positive or a credential confirmed dead, both requiring a named
person and a date. A live credential is rotated, never suppressed.
`--ignore-gitleaks-allow` disables the inline `gitleaks:allow` escape hatch so every
suppression has to land in that one reviewable file.

## Action needed from a human

**Make `Secret Scan` a required status check on `main`.** Until someone does that
in repository settings, this control is advisory: the job runs and goes red, but
nothing stops a merge. Add it to the `main` ruleset next to `ci`.

## One thing found along the way

**GitHub already blocks some secret pushes here, and it is not something we
configured.** Pushing a fake Stripe key to a scratch branch during this work was
rejected by GitHub push protection, which is on by default for public repositories
even though the repository API reports `secret_scanning_push_protection: disabled`.
It only covers high-confidence provider patterns at push time. It does not scan
history, does not gate pull requests, and does not catch generic or high-entropy
shapes, so it complements this job rather than replacing it. `squidge` is private
and gets none of it.
