### PR TITLE
chore(registry): refresh listing description and simplify publish docs

### DIFF
--- a/MCP_REGISTRY.md
+++ b/MCP_REGISTRY.md
@@ -8,13 +8,18 @@ The `server.json` file contains metadata published to the registry. It is not us
 
 ## Publishing manually
 
-1. Install the CLI: `brew install mcp-publisher`
-2. Retrieve the signing key from 1Password: `op document get "MCP Registry - meetsquad.ai signing key" --out-file key.pem`
-3. Authenticate:
+1. Bump the version in `server.json` — the registry rejects duplicate versions
+2. Paste this:
+
     ```bash
-    PRIVATE_KEY="$(openssl pkey -in key.pem -noout -text | grep -A3 "priv:" | tail -n +2 | tr -d ' :\n')"
+    mcp-publisher() { go run github.com/modelcontextprotocol/registry/cmd/publisher@v1.8.0 "$@"; }
+
+    PRIVATE_KEY="$(op item get "MCP Registry - meetsquad.ai signing key" \
+      --fields private_key --format json --reveal | jq -r .value \
+      | openssl pkey -outform DER | tail -c 32 | xxd -p -c 64)"
     mcp-publisher login dns --domain "meetsquad.ai" --private-key "${PRIVATE_KEY}"
-    rm key.pem
+
+    mcp-publisher validate && mcp-publisher publish
     ```
-4. Update the version in `server.json`
-5. Publish: `mcp-publisher publish`
+
+Needs Go and jq, or `brew install mcp-publisher`. Run `mcp-publisher logout` when you're done.

--- a/server.json
+++ b/server.json
@@ -2,12 +2,12 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "ai.meetsquad/squad",
   "title": "Squad",
-  "description": "Your AI Product Manager. Surface insights, build roadmaps, and plan strategy with 30+ tools.",
+  "description": "Decision intelligence for product teams. Turn scattered feedback into signal you can act on.",
   "repository": {
     "url": "https://github.com/the-basilisk-ai/squad-mcp",
     "source": "github"
   },
-  "version": "4.0.0",
+  "version": "4.0.2",
   "icons": [
     {
       "src": "https://assets.meetsquad.ai/images/squad-icon.png",


### PR DESCRIPTION
## Description

Registry listing carried v1-era copy:

> Your AI Product Manager. Surface insights, build roadmaps, and plan strategy with 30+ tools.

Now:

> Decision intelligence for product teams. Turn scattered feedback into signal you can act on.

Matches the Claude marketplace tagline. Dropped the tool count so it can't go stale.

## Version

`server.json` → **4.0.2**. The registry rejects duplicate versions, so a metadata-only change still needs a bump. `package.json` and `server.ts` stay at 4.0.0 — runtime version, not the listing version.

## Docs

Publish steps are now one paste-able block. The signing key moved to a 1Password SSH key item, so `op read` replaces `op document get` and the key no longer touches disk.